### PR TITLE
BACKLOG-10199: set width and height to optional in case the jcr image…

### DIFF
--- a/src/javascript/DesignSystem/ImageCard/ImageCard.js
+++ b/src/javascript/DesignSystem/ImageCard/ImageCard.js
@@ -45,7 +45,7 @@ const ImageCardCmp = ({image, classes, onDoubleClick, onClick}) => {
             <div className={classes.infoContainer}>
                 <Typography component="h3" variant="zeta" color="alpha">{image.name}</Typography>
                 <Typography variant="omega" color="gamma">
-                    {image.type} - {image.width}x{image.height}px
+                    {image.type}{(image.width && image.height) && ` - ${image.width}x${image.height}px`}
                 </Typography>
             </div>
         </Paper>
@@ -62,8 +62,8 @@ ImageCardCmp.propTypes = {
         path: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
         type: PropTypes.string.isRequired,
-        width: PropTypes.string.isRequired,
-        height: PropTypes.string.isRequired
+        width: PropTypes.string,
+        height: PropTypes.string
     }).isRequired,
     classes: PropTypes.object.isRequired,
     onDoubleClick: PropTypes.func,

--- a/src/javascript/DesignSystem/ImageCard/ImageCard.spec.js
+++ b/src/javascript/DesignSystem/ImageCard/ImageCard.spec.js
@@ -65,6 +65,20 @@ describe('imageCard', () => {
         expect(cmp.debug()).toContain('800');
     });
 
+    it('should not display the image width and height if there is no', () => {
+        defaultProps.image.width = null;
+        defaultProps.image.height = null;
+
+        const cmp = shallowWithTheme(
+            <ImageCard {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        )
+            .dive();
+
+        expect(cmp.debug()).not.toContain('px');
+    });
+
     it('should call onDoubleClick when double clicking on the the card', () => {
         const cmp = shallowWithTheme(
             <ImageCard {...defaultProps}/>,

--- a/src/javascript/DesignSystem/ImageList/ImageList.js
+++ b/src/javascript/DesignSystem/ImageList/ImageList.js
@@ -38,8 +38,8 @@ ImageListCmp.propTypes = {
     error: PropTypes.shape({message: PropTypes.string}),
     images: PropTypes.arrayOf(PropTypes.shape({
         path: PropTypes.string.isRequired,
-        width: PropTypes.string.isRequired,
-        height: PropTypes.string.isRequired
+        width: PropTypes.string,
+        height: PropTypes.string
     })),
     classes: PropTypes.object.isRequired,
     onImageDoubleClick: PropTypes.func

--- a/src/javascript/EditPanelContainer/EditPanel/EditPanelContent/FormBuilder/SelectorTypes/MediaPicker/MediaPickerDialog/MediaPickerDialog.gql-queries.js
+++ b/src/javascript/EditPanelContainer/EditPanel/EditPanelContent/FormBuilder/SelectorTypes/MediaPicker/MediaPickerDialog/MediaPickerDialog.gql-queries.js
@@ -39,7 +39,7 @@ query ($path: String!, $typeFilter: [String]!) {
 export const useImagesData = path => {
     const {data, error, loading} = useQuery(GET_FILES_QUERY, {
         variables: {
-            typeFilter: ['jnt:file'],
+            typeFilter: ['jmix:image'],
             path: path
         }
     });
@@ -57,8 +57,8 @@ export const useImagesData = path => {
                 path: `${window.contextJsParameters.contextPath}/files/default${rawImg.path}`,
                 name: rawImg.fileName.value,
                 type: rawImg.children.nodes[0].mimeType.value.replace('image/', ''),
-                width: rawImg.width.value,
-                height: rawImg.height.value
+                width: rawImg.width ? rawImg.width.value : null,
+                height: rawImg.height ? rawImg.height.value : null
             };
         }),
         error,


### PR DESCRIPTION
set width and height to optional in case the jcr image doesnt have the props (its the case for SVG), also restrict the query to jmix:image to avoid loading all kind of files