### PR TITLE
BACKLOG-11447: set field touched when unset its value

### DIFF
--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/FieldsActions/unsetField.action.js
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/FieldsActions/unsetField.action.js
@@ -11,5 +11,6 @@ export const unsetFieldAction = {
             null,
             true
         );
+        context.formik.setFieldTouched(context.field.name);
     }
 };

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/FieldsActions/unsetField.action.spec.js
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/FieldsActions/unsetField.action.spec.js
@@ -2,16 +2,20 @@ import {unsetFieldAction} from './unsetField.action';
 
 describe('unsetFieldAction', () => {
     describe('onclick', () => {
-        it('should set field value to null', () => {
-            const context = {
+        let context;
+        beforeEach(() => {
+            context = {
                 formik: {
-                    setFieldValue: jest.fn()
+                    setFieldValue: jest.fn(),
+                    setFieldTouched: jest.fn()
                 },
                 field: {
                     name: 'fieldName'
                 }
             };
+        });
 
+        it('should set field value to null', () => {
             unsetFieldAction.onClick(context);
 
             // As action expect impure function, testing params
@@ -20,6 +24,12 @@ describe('unsetFieldAction', () => {
                 null,
                 true
             );
+        });
+
+        it('should set field touched', () => {
+            unsetFieldAction.onClick(context);
+
+            expect(context.formik.setFieldTouched).toHaveBeenCalledWith('fieldName');
         });
     });
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-11447

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [X] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [ ] Migration
- [X] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
