### PR TITLE
BACKLOG-12511 : call gwt refresh content function only if necessary

### DIFF
--- a/src/javascript/Edit/save/save.request.js
+++ b/src/javascript/Edit/save/save.request.js
@@ -53,7 +53,9 @@ export const saveNode = ({
         notificationContext.notify(t('content-editor:label.contentEditor.edit.action.save.success'), ['closeButton']);
 
         // Refresh GWT content
-        window.top.authoringApi.refreshContent();
+        if (window.top.authoringApi.refreshContent) {
+            window.top.authoringApi.refreshContent();
+        }
 
         actions.setSubmitting(false);
         refetchPreview(getPreviewPath(nodeData), language);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12511