### PR TITLE
BACKLOG-12981 : update wip modal labels, design and rename the wip link property

### DIFF
--- a/src/javascript/EditPanel/WorkInProgress/WorkInProgressDialog/WorkInProgressDialog.jsx
+++ b/src/javascript/EditPanel/WorkInProgress/WorkInProgressDialog/WorkInProgressDialog.jsx
@@ -72,7 +72,7 @@ export const WorkInProgressDialog = ({
             onClose={onCloseDialog}
         >
             <DialogTitle id="dialog-language-title">
-                <Typography isUpperCase variant="heading" weight="bold" className={classes.dialogTitle}>
+                <Typography variant="heading" weight="bold" className={classes.dialogTitle}>
                     {t('content-editor:label.contentEditor.edit.action.workInProgress.dialogTitle')}
                 </Typography>
                 <Typography className={classes.dialogSubTitle}>
@@ -81,7 +81,7 @@ export const WorkInProgressDialog = ({
                         className={classes.link}
                         target="_blank"
                         rel="noopener noreferrer"
-                        href={window.contextJsParameters.config.academyLink}
+                        href={window.contextJsParameters.config.wip}
                     >{t('content-editor:label.contentEditor.edit.action.workInProgress.clickHere')}
                     </a>
                 </Typography>
@@ -91,7 +91,7 @@ export const WorkInProgressDialog = ({
                     <div>
                         <Checkbox
                             data-sel-role="WIP"
-                            className={classes.checkbox}
+                            className={wipStatus ? classes.checkboxChecked : ''}
                             checked={wipStatus}
                             onChange={onChangeWip}
                         />
@@ -102,12 +102,8 @@ export const WorkInProgressDialog = ({
                         </Typography>
 
                         {!wipStatus &&
-                        <Typography className={classes.label}>
+                        <Typography className={classes.label} variant="caption">
                             {t('content-editor:label.contentEditor.edit.action.workInProgress.checkboxSubLabel')}
-                        </Typography>}
-                        {wipStatus &&
-                        <Typography className={classes.label}>
-                            {t('content-editor:label.contentEditor.edit.action.workInProgress.checkboxSubLabelCannotBePublished')}
                         </Typography>}
                     </div>
                 </div>
@@ -126,15 +122,12 @@ export const WorkInProgressDialog = ({
                         </Typography>
                     </div>
                     <div className={classes.languageSelectionContainer}>
-                        <Typography className={classes.label}>
-                            {t('content-editor:label.contentEditor.edit.action.workInProgress.localizedPropertiesOnlySubText')}
-                        </Typography>
                         {languages.map(language => {
                             return (
                                 <div key={language.language}>
                                     <Checkbox
                                         disabled={!wipStatus || statusSelected !== Constants.wip.status.LANGUAGES}
-                                        className={classes.checkbox}
+                                        className={selectedLanguages.indexOf(language.language) > -1 ? classes.checkboxChecked : ''}
                                         value={language.language}
                                         checked={selectedLanguages.indexOf(language.language) > -1}
                                         onChange={event => {
@@ -145,9 +138,11 @@ export const WorkInProgressDialog = ({
                                         {language.displayName}
                                     </Typography>
                                 </div>
-
                             );
                         })}
+                        <Typography className={classes.label} variant="caption">
+                            {t('content-editor:label.contentEditor.edit.action.workInProgress.localizedPropertiesOnlySubText')}
+                        </Typography>
                     </div>
                     <div className={classes.radioButtonEntry}>
                         <Radio
@@ -157,12 +152,14 @@ export const WorkInProgressDialog = ({
                             value={Constants.wip.status.ALL_CONTENT}
                             onChange={handleLocalisedOrAllContent}
                         />
-                        <Typography className={classes.label}>
-                            {t('content-editor:label.contentEditor.edit.action.workInProgress.allContent')}
-                        </Typography>
-                        <Typography className={classes.subTextAllContent}>
-                            {t('content-editor:label.contentEditor.edit.action.workInProgress.allContentSubText')}
-                        </Typography>
+                        <div>
+                            <Typography className={classes.label}>
+                                {t('content-editor:label.contentEditor.edit.action.workInProgress.allContent')}
+                            </Typography>
+                            <Typography className={classes.subTextAllContent} variant="caption">
+                                {t('content-editor:label.contentEditor.edit.action.workInProgress.allContentSubText')}
+                            </Typography>
+                        </div>
                     </div>
                 </div>}
             </DialogContent>

--- a/src/javascript/EditPanel/WorkInProgress/WorkInProgressDialog/WorkInProgressDialog.scss
+++ b/src/javascript/EditPanel/WorkInProgress/WorkInProgressDialog/WorkInProgressDialog.scss
@@ -1,4 +1,4 @@
-.checkbox {
+.checkboxChecked {
     color: #0072b1 !important;
 }
 
@@ -7,7 +7,7 @@
 }
 
 .dialogTitle {
-    margin: 0 10px;
+    margin: var(--spacing-medium) 10px;
 
     color: #373c42;
 }
@@ -69,8 +69,6 @@
 }
 
 .subTextAllContent {
-    padding-left: var(--spacing-big);
-
     font-weight: lighter;
 }
 

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -78,13 +78,12 @@
             "btnDone": "Anwenden",
             "checkboxLabel": "In Arbeit.",
             "checkboxSubLabel": "Der Content kann in allen Sprachen veröffentlicht werden.",
-            "checkboxSubLabelCannotBePublished": "Der Content kann nicht veröffentlicht werden.",
             "clickHere": "klicken Sie hier.",
             "dialogTitle": "In Arbeit (WIP)",
             "dialogSubTitle": "Markieren Sie Ihren Content als Work in Progress wenn Sie die Veröffentlichung des Contents verhindern wollen. Um mehr über das Work in Progress Feature zu erfahren, ",
             "label": "Als \"In Arbeit\" markieren",
             "localizedPropertiesOnly": "Nur sprachabhängige Eigenschaften in:",
-            "localizedPropertiesOnlySubText": "Der Inhalt der selektierten Sprache wird nicht veröffentlicht. Gemeinsame Eigenschaften hingegen können als Teil einer nicht selektierten Sprache veröffentlicht werden.",
+            "localizedPropertiesOnlySubText": "Der Inhalt der selektierten Sprache wird nicht veröffentlicht. Trotzdem können Properties, die von allen Sprachen verwendet werden, Teil eines Veröffentlichungs-Prozesses einer nicht ausgewählten Sprache sein.",
             "allContent": "Gesamter Inhalt (gemeinsame und sprachabhängige Eigenschaften)",
             "allContentSubText": "Die Option \"Gesamter Inhalt\" verhindert die Veröffentlichung in allen Sprachen. "
           }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -78,13 +78,12 @@
             "btnDone": "Done",
             "checkboxLabel": "Work in progress.",
             "checkboxSubLabel": "The content can be published in all languages.",
-            "checkboxSubLabelCannotBePublished": "The content cannot be published.",
             "clickHere": "click here.",
             "dialogTitle": "Work in progress (WIP)",
-            "dialogSubTitle": "Mark your content as work in progress if you want to prevent the publication of your content. If you wish to find out more about Work in progress ",
+            "dialogSubTitle": "Mark your content as work in progress if you want to prevent the publication of your content. To find out more about Work in progress ",
             "label": "Mark as Work in progress",
             "localizedPropertiesOnly": "Localised properties only in:",
-            "localizedPropertiesOnlySubText": "The content won’t be publishable in the selected languages. Common properties can however be part of a publication in a non-selected language.",
+            "localizedPropertiesOnlySubText": "The content won't be publishable in the selected languages. However, properties that are shared by all languages can be part of a publication in a non-selected language.",
             "allContent": "All content (localised & properties)",
             "allContentSubText": "The \"All Content\" option prevents any publication in any language."
           }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -78,13 +78,12 @@
             "btnDone": "Valider",
             "checkboxLabel": "Travail en cours.",
             "checkboxSubLabel": "Le contenu peut être publié dans toutes les langues.",
-            "checkboxSubLabelCannotBePublished": "Le contenu ne peut pas être publié.",
             "clickHere": "cliquez ici.",
             "dialogTitle": "Travail en cours (WIP)",
-            "dialogSubTitle": "Vous pouvez marquer comme travail en cours pour en empêcher sa publication. Si vous souhaitez en savoir plus sur l'option Marquer comme travail en cours, ",
+            "dialogSubTitle": "Vous pouvez marquer comme travail en cours pour en empêcher sa publication. Pour en savoir plus sur l'option Marquer comme travail en cours, ",
             "label": "Marquer comme travail en cours",
             "localizedPropertiesOnly": "Propriétés internationalisées seulement:",
-            "localizedPropertiesOnlySubText": "Le contenu ne sera pas publiable dans les langues sélectionnées. Les propriétés communes à toutes les langues peuvent cependant faire partie d'une publication dans une autre langue.",
+            "localizedPropertiesOnlySubText": "Le contenu ne sera pas publiable dans les langues sélectionnées. Cependant, Les propriétés communes à toutes les langues peuvent cependant faire partie d'une publication dans une autre langue.",
             "allContent": "Tout le contenu (propriétés communes et internationalisées)",
             "allContentSubText": "L'option \"Tout le contenu\" empêche toute publication dans n'importe quelle langue."
           }

--- a/src/main/resources/jnt_globalSettings/js/globalSettings.contentEditor.jsp
+++ b/src/main/resources/jnt_globalSettings/js/globalSettings.contentEditor.jsp
@@ -1,3 +1,3 @@
 <%@ page import="org.jahia.settings.SettingsBean"%><%@ page language="java" contentType="text/javascript" %>
-contextJsParameters.config.academyLink="<%= SettingsBean.getInstance().getString("academyUrl",
-"https://academy.jahia.com/documentation/digital-experience-manager/8.0/functional/how-to-contribute-content#Work_in_Progress")%>;"
+contextJsParameters.config.wip="<%= SettingsBean.getInstance().getString("wip.link",
+"https://academy.jahia.com/documentation/digital-experience-manager/8.0/functional/how-to-contribute-content#Work_in_Progress")%>"


### PR DESCRIPTION
In addition to this ticket I modified the name of the property containing
the link to academy from academyUrl to academyUrlWip to avoid this link
to be replaced by another one

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12981