### PR TITLE
BACKLOG-13053 : disable publish button for WIP contents

### DIFF
--- a/src/javascript/Edit/publish/publish.action.jsx
+++ b/src/javascript/Edit/publish/publish.action.jsx
@@ -14,10 +14,13 @@ export default composeActions(
                     context.publicationInfoContext.stopPublicationInfoPolling();
                 }
 
+                const wipInfo = context.formik.values[Constants.wip.fieldName];
                 context.disabled = context.publicationInfoContext.publicationStatus === undefined ||
                     context.publicationInfoContext.publicationInfoPolling ||
                     context.nodeData.lockedAndCannotBeEdited ||
                     context.formik.dirty ||
+                    wipInfo.status === Constants.wip.status.ALL_CONTENT ||
+                    (wipInfo.status === Constants.wip.status.LANGUAGES && wipInfo.languages.includes(context.language)) ||
                     [
                         Constants.editPanel.publicationStatus.PUBLISHED,
                         Constants.editPanel.publicationStatus.MANDATORY_LANGUAGE_UNPUBLISHABLE

--- a/src/javascript/Edit/publish/publish.action.spec.js
+++ b/src/javascript/Edit/publish/publish.action.spec.js
@@ -26,6 +26,7 @@ jest.mock('./publish.request', () => {
 });
 
 import {publishNode} from './publish.request';
+import {Constants} from '~/ContentEditor.constants';
 
 describe('publish action', () => {
     describe('onClick', () => {
@@ -53,7 +54,12 @@ describe('publish action', () => {
                     lockedAndCannotBeEdited: false
                 },
                 formik: {
-                    dirty: false
+                    dirty: false,
+                    values: {
+                        'WIP::Info': {
+                            status: 'DISABLED'
+                        }
+                    }
                 },
                 publicationInfoContext: {
                     publicationStatus: 'MODIFIED',
@@ -66,6 +72,20 @@ describe('publish action', () => {
 
         it('should disabled submit action when form is dirty', () => {
             context.formik.dirty = true;
+            publishAction.init(context);
+            expect(context.disabled).toBe(true);
+        });
+
+        it('should disabled submit action when node is in WIP for all content', () => {
+            context.formik.values[Constants.wip.fieldName].status = Constants.wip.status.ALL_CONTENT;
+            publishAction.init(context);
+            expect(context.disabled).toBe(true);
+        });
+
+        it('should disabled submit action when node is in WIP for current language', () => {
+            context.formik.values[Constants.wip.fieldName].status = Constants.wip.status.LANGUAGES;
+            context.formik.values[Constants.wip.fieldName].languages = ['en', 'fr'];
+            context.language = 'en';
             publishAction.init(context);
             expect(context.disabled).toBe(true);
         });


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-13053
disable publish button when content is in work in progress

covered by unit tests