### PR TITLE
BACKLOG-12779 : make content editor work properly with GWT modal windows

### DIFF
--- a/src/javascript/Api/ContentEditor.api.jsx
+++ b/src/javascript/Api/ContentEditor.api.jsx
@@ -14,7 +14,7 @@ let styles = () => {
     return {
         ceDialogRoot: {
             // Reduce zIndex to be able to display the old edit engine tabs
-            zIndex: 1050,
+            zIndex: 1031,
             width: 'calc(100vw - 56px)',
             left: 'unset',
             right: 0


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-12779 
fix Content Editor / GWT engines display issues
Covered by integration tests