### PR TITLE
BACKLOG-13045: display 'not published', 'live', 'modified' and 'warni…

### DIFF
--- a/src/javascript/EditPanel/header/UpperSection.scss
+++ b/src/javascript/EditPanel/header/UpperSection.scss
@@ -38,6 +38,12 @@
             right: 92px;
         }
     }
+
+    .headerChips {
+        & > * {
+            margin-left: var(--spacing-small);
+        }
+    }
 }
 
 .mainActions {

--- a/src/javascript/PublicationInfo/PublicationInfo.badge.jsx
+++ b/src/javascript/PublicationInfo/PublicationInfo.badge.jsx
@@ -42,7 +42,7 @@ export const PublicationInfoBadge = () => {
             {!publicationInfoContext.publicationInfoPolling &&
             <>
                 {statuses.modified && renderStatus('modified')}
-                {renderStatus(statuses.published ? 'published' : 'notPublished')}
+                {!statuses.warning && renderStatus(statuses.published ? 'published' : 'notPublished')}
                 {statuses.warning && renderStatus('warning')}
             </>}
             {publicationInfoContext.publicationInfoPolling && renderStatus('publishing')}

--- a/src/javascript/PublicationInfo/PublicationInfo.badge.jsx
+++ b/src/javascript/PublicationInfo/PublicationInfo.badge.jsx
@@ -1,21 +1,51 @@
 import React from 'react';
-import {Chip} from '@jahia/moonstone';
-import {FileContent} from '@jahia/moonstone/dist/icons';
 import {usePublicationInfoContext} from './PublicationInfo.context';
 import {useTranslation} from 'react-i18next';
+import {Constants} from '~/ContentEditor.constants';
+import PublicationStatus from './PublicationInfo.status';
+import {getTooltip} from './PublicationInfo.tooltip';
+import {useContentEditorConfigContext} from '~/ContentEditor.context';
 
 export const PublicationInfoBadge = () => {
-    const {t} = useTranslation();
-    const {publicationInfoPolling} = usePublicationInfoContext();
+    const {t} = useTranslation('content-editor');
+    const publicationInfoContext = usePublicationInfoContext();
+    const {uilang} = useContentEditorConfigContext();
+
+    const statuses = {
+        modified: false,
+        published: false,
+        warning: false
+    };
+
+    // This rules have been extracted from JContent, please maintain this rules to be consistent with JContent
+    if (publicationInfoContext.publicationStatus) {
+        if (publicationInfoContext.publicationStatus === Constants.editPanel.publicationStatus.MODIFIED) {
+            statuses.modified = true;
+            statuses.published = true;
+        } else if (publicationInfoContext.publicationStatus === Constants.editPanel.publicationStatus.NOT_PUBLISHED) {
+            statuses.published = false;
+        } else if (publicationInfoContext.publicationStatus === Constants.editPanel.publicationStatus.PUBLISHED) {
+            statuses.published = true;
+        } else if (publicationInfoContext.publicationStatus === Constants.editPanel.publicationStatus.UNPUBLISHED) {
+            statuses.published = false;
+        } else if (publicationInfoContext.publicationStatus !== Constants.editPanel.publicationStatus.MARKED_FOR_DELETION) {
+            statuses.warning = true;
+        }
+    }
+
+    const supportedUiLang = Constants.supportedLocales.includes(uilang) ? uilang : Constants.defaultLocale;
+    const renderStatus = type => (
+        <PublicationStatus type={type} tooltip={getTooltip(type, publicationInfoContext, supportedUiLang, t)}/>
+    );
     return (
         <>
-            {publicationInfoPolling &&
-            <Chip
-                data-sel-role="publication-info-polling-badge"
-                label={t('content-editor:label.contentEditor.edit.action.publish.badge')}
-                icon={<FileContent/>}
-                color="default"
-            />}
+            {!publicationInfoContext.publicationInfoPolling &&
+            <>
+                {statuses.modified && renderStatus('modified')}
+                {renderStatus(statuses.published ? 'published' : 'notPublished')}
+                {statuses.warning && renderStatus('warning')}
+            </>}
+            {publicationInfoContext.publicationInfoPolling && renderStatus('publishing')}
         </>
     );
 };

--- a/src/javascript/PublicationInfo/PublicationInfo.badge.spec.js
+++ b/src/javascript/PublicationInfo/PublicationInfo.badge.spec.js
@@ -103,31 +103,27 @@ describe('PublicationInfo.badge', () => {
         let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
 
         expect(wrapper.containsMatchingElement(<PublicationStatus type="warning" tooltip="translated_label.contentEditor.publicationStatusTooltip.conflict"/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
-        expect(wrapper.find('PublicationStatus')).toHaveLength(2);
+        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
     });
 
     it('Should display "warning" badge when MANDATORY_LANGUAGE_VALID publication info', () => {
         let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
 
         expect(wrapper.containsMatchingElement(<PublicationStatus type="warning" tooltip="translated_label.contentEditor.publicationStatusTooltip.mandatoryLanguageValid"/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
-        expect(wrapper.find('PublicationStatus')).toHaveLength(2);
+        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
     });
 
     it('Should display "warning" badge when MANDATORY_LANGUAGE_UNPUBLISHABLE publication info', () => {
         let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
 
         expect(wrapper.containsMatchingElement(<PublicationStatus type="warning" tooltip="translated_label.contentEditor.publicationStatusTooltip.mandatoryLanguageUnpublishable"/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
-        expect(wrapper.find('PublicationStatus')).toHaveLength(2);
+        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
     });
 
     it('Should display "warning" badge when unknown publication info', () => {
         let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
 
         expect(wrapper.containsMatchingElement(<PublicationStatus type="warning" tooltip="translated_label.contentEditor.publicationStatusTooltip.unknown"/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
-        expect(wrapper.find('PublicationStatus')).toHaveLength(2);
+        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
     });
 });

--- a/src/javascript/PublicationInfo/PublicationInfo.badge.spec.js
+++ b/src/javascript/PublicationInfo/PublicationInfo.badge.spec.js
@@ -1,27 +1,133 @@
 import {PublicationInfoBadge} from './PublicationInfo.badge';
 import React from 'react';
 import {shallow} from '@jahia/test-framework';
+import PublicationStatus from './PublicationInfo.status';
 
 jest.mock('./PublicationInfo.context', () => {
-    let called = false;
+    let callCount = 0;
+    const contexts = [
+        {
+            publicationInfoPolling: true
+        },
+        {
+            publicationInfoPolling: false
+        },
+        {
+            publicationInfoPolling: false,
+            publicationStatus: 'MODIFIED'
+        },
+        {
+            publicationInfoPolling: false,
+            publicationStatus: 'NOT_PUBLISHED'
+        },
+        {
+            publicationInfoPolling: false,
+            publicationStatus: 'PUBLISHED'
+        },
+        {
+            publicationInfoPolling: false,
+            publicationStatus: 'UNPUBLISHED'
+        },
+        {
+            publicationInfoPolling: false,
+            publicationStatus: 'CONFLICT'
+        },
+        {
+            publicationInfoPolling: false,
+            publicationStatus: 'MANDATORY_LANGUAGE_VALID'
+        },
+        {
+            publicationInfoPolling: false,
+            publicationStatus: 'MANDATORY_LANGUAGE_UNPUBLISHABLE'
+        },
+        {
+            publicationInfoPolling: false,
+            publicationStatus: 'UNKNOWN_STATUS'
+        }
+    ];
     return {
         usePublicationInfoContext: () => {
-            called = !called;
-            return {
-                publicationInfoPolling: called
-            };
+            const context = contexts[callCount];
+            callCount++;
+
+            return context;
         }
     };
 });
 
 describe('PublicationInfo.badge', () => {
-    it('Should display badge when publication info is polling', () => {
+    it('Should display "publishing" badge when publication info is polling', () => {
         let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
-        expect(wrapper.debug()).toContain('Chip');
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="publishing"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
     });
 
-    it('Should not display badge when publication info is not polling', () => {
+    it('Should not display "publishing" badge when publication info is not polling', () => {
         let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
-        expect(wrapper.debug()).not.toContain('Chip');
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
+    });
+
+    it('Should display "modified" and "live" badges when MODIFIED publication info', () => {
+        let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="modified" tooltip="translated_label.contentEditor.publicationStatusTooltip.modified"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="published" tooltip="translated_label.contentEditor.publicationStatusTooltip.published"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(2);
+    });
+
+    it('Should display "not published" badge when NOT_PUBLISHED publication info', () => {
+        let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
+    });
+
+    it('Should display "live" badge when PUBLISHED publication info', () => {
+        let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="published" tooltip="translated_label.contentEditor.publicationStatusTooltip.published"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
+    });
+
+    it('Should display "not published" badge when UNPUBLISHED publication info', () => {
+        let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
+    });
+
+    it('Should display "warning" badge when CONFLICT publication info', () => {
+        let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="warning" tooltip="translated_label.contentEditor.publicationStatusTooltip.conflict"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(2);
+    });
+
+    it('Should display "warning" badge when MANDATORY_LANGUAGE_VALID publication info', () => {
+        let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="warning" tooltip="translated_label.contentEditor.publicationStatusTooltip.mandatoryLanguageValid"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(2);
+    });
+
+    it('Should display "warning" badge when MANDATORY_LANGUAGE_UNPUBLISHABLE publication info', () => {
+        let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="warning" tooltip="translated_label.contentEditor.publicationStatusTooltip.mandatoryLanguageUnpublishable"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(2);
+    });
+
+    it('Should display "warning" badge when unknown publication info', () => {
+        let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="warning" tooltip="translated_label.contentEditor.publicationStatusTooltip.unknown"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.find('PublicationStatus')).toHaveLength(2);
     });
 });

--- a/src/javascript/PublicationInfo/PublicationInfo.context.js
+++ b/src/javascript/PublicationInfo/PublicationInfo.context.js
@@ -10,7 +10,7 @@ export const usePublicationInfoContext = () => useContext(PublicationInfoContext
 export const PublicationInfoContextProvider = ({uuid, lang, children}) => {
     const {t} = useTranslation();
     const {
-        publicationInfoError, publicationInfoErrorMessage, publicationStatus, publicationInfoPolling, startPublicationInfoPolling, stopPublicationInfoPolling
+        publicationInfoError, publicationInfoErrorMessage, ...publicationInfoContext
     } = usePublicationInfo({
         uuid: uuid,
         language: lang
@@ -20,8 +20,6 @@ export const PublicationInfoContextProvider = ({uuid, lang, children}) => {
         console.error(publicationInfoError);
         return <>{publicationInfoErrorMessage}</>;
     }
-
-    const publicationInfoContext = {publicationStatus, publicationInfoPolling, startPublicationInfoPolling, stopPublicationInfoPolling};
 
     return (
         <PublicationInfoContext.Provider value={publicationInfoContext}>

--- a/src/javascript/PublicationInfo/PublicationInfo.gql-queries.js
+++ b/src/javascript/PublicationInfo/PublicationInfo.gql-queries.js
@@ -9,16 +9,16 @@ export const PublicationInfoQuery = gql`
                 aggregatedPublicationInfo(language: $language, subNodes: false, references: false) {
                     publicationStatus
                 }
-                lastModifiedBy:property(name:"jcr:lastModifiedBy"){
+                lastModifiedBy:property(name:"jcr:lastModifiedBy", language: $language){
                     value
                 }
-                lastModified:property(name:"jcr:lastModified"){
+                lastModified:property(name:"jcr:lastModified", language: $language){
                     value
                 }
-                lastPublishedBy:property(name:"j:lastPublishedBy"){
+                lastPublishedBy:property(name:"j:lastPublishedBy", language: $language){
                     value
                 }
-                lastPublished:property(name:"j:lastPublished"){
+                lastPublished:property(name:"j:lastPublished", language: $language){
                     value
                 }
             }

--- a/src/javascript/PublicationInfo/PublicationInfo.gql-queries.js
+++ b/src/javascript/PublicationInfo/PublicationInfo.gql-queries.js
@@ -9,6 +9,18 @@ export const PublicationInfoQuery = gql`
                 aggregatedPublicationInfo(language: $language, subNodes: false, references: false) {
                     publicationStatus
                 }
+                lastModifiedBy:property(name:"jcr:lastModifiedBy"){
+                    value
+                }
+                lastModified:property(name:"jcr:lastModified"){
+                    value
+                }
+                lastPublishedBy:property(name:"j:lastPublishedBy"){
+                    value
+                }
+                lastPublished:property(name:"j:lastPublished"){
+                    value
+                }
             }
         }
     }

--- a/src/javascript/PublicationInfo/PublicationInfo.jsx
+++ b/src/javascript/PublicationInfo/PublicationInfo.jsx
@@ -21,6 +21,10 @@ export const usePublicationInfo = (queryParams, t) => {
 
     return {
         publicationStatus: data.jcr.nodeById.aggregatedPublicationInfo.publicationStatus,
+        lastModified: data.jcr.nodeById.lastModified?.value,
+        lastModifiedBy: data.jcr.nodeById.lastModifiedBy?.value,
+        lastPublished: data.jcr.nodeById.lastPublished?.value,
+        lastPublishedBy: data.jcr.nodeById.lastPublishedBy?.value,
         publicationInfoPolling: polling,
         startPublicationInfoPolling: () => {
             setPolling(true);

--- a/src/javascript/PublicationInfo/PublicationInfo.status.jsx
+++ b/src/javascript/PublicationInfo/PublicationInfo.status.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {useTranslation} from 'react-i18next';
+import {Chip} from '@jahia/moonstone';
+import {Cloud, File, FileContent, NoCloud, Warning} from '@jahia/moonstone/dist/icons';
+
+const config = {
+    modified: {
+        color: 'default',
+        icon: <File/>,
+        'data-sel-role': 'publication-info-modified-badge'
+    },
+    notPublished: {
+        color: 'warning',
+        icon: <NoCloud/>,
+        'data-sel-role': 'publication-info-notPublished-badge'
+    },
+    published: {
+        color: 'accent',
+        icon: <Cloud/>,
+        'data-sel-role': 'publication-info-published-badge'
+    },
+    warning: {
+        color: 'warning',
+        icon: <Warning/>,
+        'data-sel-role': 'publication-info-warning-badge'
+    },
+    publishing: {
+        color: 'default',
+        icon: <FileContent/>,
+        'data-sel-role': 'publication-info-polling-badge'
+    }
+};
+
+const types = Object.keys(config);
+
+const PublicationStatus = ({type, tooltip}) => {
+    const {t} = useTranslation('content-editor');
+    const label = t(`label.contentEditor.publicationStatusBadge.${type}`);
+    return (
+        <Chip label={label} title={tooltip || label} {...config[type]}/>
+    );
+};
+
+PublicationStatus.propTypes = {
+    type: PropTypes.oneOf(types).isRequired,
+    tooltip: PropTypes.string
+};
+
+export default PublicationStatus;

--- a/src/javascript/PublicationInfo/PublicationInfo.status.spec.js
+++ b/src/javascript/PublicationInfo/PublicationInfo.status.spec.js
@@ -1,0 +1,51 @@
+import PublicationInfoStatus from './PublicationInfo.status';
+import React from 'react';
+import {shallow} from '@jahia/test-framework';
+import {Cloud, FileContent, File, NoCloud, Warning} from '@jahia/moonstone/dist/icons';
+
+describe('PublicationInfo.status', () => {
+    it('Should display not published chip', () => {
+        let wrapper = shallow(<PublicationInfoStatus type="notPublished"/>);
+
+        expect(wrapper.find('Chip').exists()).toBeTruthy();
+        expect(wrapper.props().label).toBe('translated_label.contentEditor.publicationStatusBadge.notPublished');
+        expect(wrapper.props().color).toBe('warning');
+        expect(wrapper.props().icon).toStrictEqual(<NoCloud/>);
+    });
+
+    it('Should display modified chip', () => {
+        let wrapper = shallow(<PublicationInfoStatus type="modified"/>);
+
+        expect(wrapper.find('Chip').exists()).toBeTruthy();
+        expect(wrapper.props().label).toBe('translated_label.contentEditor.publicationStatusBadge.modified');
+        expect(wrapper.props().color).toBe('default');
+        expect(wrapper.props().icon).toStrictEqual(<File/>);
+    });
+
+    it('Should display published chip', () => {
+        let wrapper = shallow(<PublicationInfoStatus type="published"/>);
+
+        expect(wrapper.find('Chip').exists()).toBeTruthy();
+        expect(wrapper.props().label).toBe('translated_label.contentEditor.publicationStatusBadge.published');
+        expect(wrapper.props().color).toBe('accent');
+        expect(wrapper.props().icon).toStrictEqual(<Cloud/>);
+    });
+
+    it('Should display warning chip', () => {
+        let wrapper = shallow(<PublicationInfoStatus type="warning"/>);
+
+        expect(wrapper.find('Chip').exists()).toBeTruthy();
+        expect(wrapper.props().label).toBe('translated_label.contentEditor.publicationStatusBadge.warning');
+        expect(wrapper.props().color).toBe('warning');
+        expect(wrapper.props().icon).toStrictEqual(<Warning/>);
+    });
+
+    it('Should display publishing chip', () => {
+        let wrapper = shallow(<PublicationInfoStatus type="publishing"/>);
+
+        expect(wrapper.find('Chip').exists()).toBeTruthy();
+        expect(wrapper.props().label).toBe('translated_label.contentEditor.publicationStatusBadge.publishing');
+        expect(wrapper.props().color).toBe('default');
+        expect(wrapper.props().icon).toStrictEqual(<FileContent/>);
+    });
+});

--- a/src/javascript/PublicationInfo/PublicationInfo.tooltip.js
+++ b/src/javascript/PublicationInfo/PublicationInfo.tooltip.js
@@ -1,0 +1,58 @@
+import dayjs from 'dayjs';
+import {Constants} from '../ContentEditor.constants';
+
+function formatDate(date, locale, format = 'LLL') {
+    return dayjs(date).locale(locale).format(format);
+}
+
+const tooltips = {
+    modified: (publicationInfoContext, uilang) => {
+        return {
+            key: 'label.contentEditor.publicationStatusTooltip.modified',
+            args: {
+                userName: publicationInfoContext.lastModifiedBy || '?',
+                timestamp: formatDate(publicationInfoContext.lastModified, uilang)
+            }
+        };
+    },
+    published: (publicationInfoContext, uilang) => {
+        return {
+            key: 'label.contentEditor.publicationStatusTooltip.published',
+            args: {
+                userName: publicationInfoContext.lastPublishedBy || '?',
+                timestamp: formatDate(publicationInfoContext.lastPublished, uilang)
+            }
+        };
+    },
+    warning: publicationInfoContext => {
+        const resolveKey = status => {
+            switch (status) {
+                case Constants.editPanel.publicationStatus.CONFLICT:
+                    return 'label.contentEditor.publicationStatusTooltip.conflict';
+                case Constants.editPanel.publicationStatus.MANDATORY_LANGUAGE_VALID:
+                    return 'label.contentEditor.publicationStatusTooltip.mandatoryLanguageValid';
+                case Constants.editPanel.publicationStatus.MANDATORY_LANGUAGE_UNPUBLISHABLE:
+                    return 'label.contentEditor.publicationStatusTooltip.mandatoryLanguageUnpublishable';
+                default:
+                    return 'label.contentEditor.publicationStatusTooltip.unknown';
+            }
+        };
+
+        return {
+            key: resolveKey(publicationInfoContext.publicationStatus)
+        };
+    }
+};
+
+function getTooltip(type, publicationInfoContext, uilang, t) {
+    const provider = tooltips[type];
+
+    if (provider) {
+        const tooltip = provider(publicationInfoContext, uilang);
+        return t(tooltip.key, tooltip.args);
+    }
+
+    return '';
+}
+
+export {getTooltip};

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -57,8 +57,7 @@
             "name": "Jetzt veröffentlichen",
             "namePolling": "Veröffentlichung",
             "success": "Veröffentlichung der Warteschlange hinzugefügt",
-            "error": "Fehler während Veröffentlichung",
-            "badge": "Veröffentlichung in Bearbeitung"
+            "error": "Fehler während Veröffentlichung"
           },
           "startWorkflow": {
             "name": "Veröffentlichung anfordern"
@@ -215,6 +214,21 @@
       },
       "siteSwitcher": {
         "allSites": "Alle Sites"
+      },
+      "publicationStatusBadge": {
+        "publishing": "Veröffentlichung in Bearbeitung",
+        "modified": "Geändert",
+        "notPublished": "Nicht veröffentlicht",
+        "published": "Live",
+        "warning": "Achtung",
+      },
+      "publicationStatusTooltip": {
+        "modified": "Geändert von {{userName}} am {{timestamp}}",
+        "published": "Veröffentlicht von {{userName}} am {{timestamp}}",
+        "mandatoryLanguageUnpublishable": "Der Inhalt kann nicht in der aktuellen Sprache veröffentlicht werden, da verpflichtende Eigenschaften fehlen.",
+        "mandatoryLanguageValid": "Der Inhalt wird live sichtbar, wenn eine Veröffentlichung in allen verpflichtenden Sprachen durchgeführt wurde.",
+        "conflict": "Content existiert im Live-Modus mit dem gleichem Namen und wird in der Veröffentlichung deshalb nicht berücksichtigt.",
+        "unknown": "Veröffentlichungsstatus nicht verfügbar"
       }
     }
   }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -57,8 +57,7 @@
             "name": "Publish now",
             "namePolling": "Publishing",
             "success": "Publication has been queued",
-            "error": "Error while publishing",
-            "badge": "Publication in progress"
+            "error": "Error while publishing"
           },
           "startWorkflow": {
             "name": "Request publication"
@@ -215,6 +214,21 @@
       },
       "siteSwitcher": {
         "allSites": "All Sites"
+      },
+      "publicationStatusBadge": {
+        "publishing": "Publication in progress",
+        "published": "Live",
+        "notPublished": "Not published",
+        "modified": "Modified",
+        "warning": "Warning"
+      },
+      "publicationStatusTooltip": {
+        "modified": "Modified by {{userName}} on {{timestamp}}",
+        "published": "Published by {{userName}} on {{timestamp}}",
+        "mandatoryLanguageUnpublishable": "Content cannot be published in the current language because of a missing mandatory property",
+        "mandatoryLanguageValid": "Content will be visible in live once published in all the mandatory languages.",
+        "conflict": "Content with the same name already exists in live and won't be part of this publication",
+        "unknown": "Publication status unavailable"
       }
     }
   }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -57,8 +57,7 @@
             "name": "Publier maintenant",
             "namePolling": "Publication",
             "success": "La publication a été ajoutée à la file d’attente",
-            "error": "Erreur durant la publication",
-            "badge": "Publication en cours"
+            "error": "Erreur durant la publication"
           },
           "startWorkflow": {
             "name": "Demander une publication"
@@ -215,6 +214,21 @@
       },
       "siteSwitcher": {
         "allSites": "Tous les Sites"
+      },
+      "publicationStatusBadge": {
+        "publishing": "Publication en cours",
+        "modified": "Modifié",
+        "notPublished": "Non publié",
+        "published": "Live",
+        "warning": "Attention",
+      },
+      "publicationStatusTooltip": {
+        "modified": "Modifié par {{userName}} le {{timestamp}}",
+        "published": "Publié par {{userName}} le {{timestamp}}",
+        "mandatoryLanguageUnpublishable": "Le contenu ne peut pas être publié dans la langue courante car une propriété obligatoire n'est pas renseignée.",
+        "mandatoryLanguageValid": "Le contenu ne sera visible en ligne qu'après publication dans toutes les langues obligatoires.",
+        "conflict": "Un contenu avec le même nom existe déjà en mode live et ne fera pas partie de cette publication",
+        "unknown": "Statut de publication indisponible"
       }
     }
   }


### PR DESCRIPTION
display 'not published', 'live', 'modified' and 'warning' badges, based on jcontent display rules

fully covered by react tests
