### PR TITLE
BACKLOG-13066 : use new action framework for create and save actions

### DIFF
--- a/src/javascript/Create/CreateForm/create.action.js
+++ b/src/javascript/Create/CreateForm/create.action.js
@@ -1,28 +1,46 @@
-import {composeActions, componentRendererAction} from '@jahia/react-material';
 import {Constants} from '~/ContentEditor.constants';
 import {validateForm} from '~/Validation/validation.utils';
+import React, {useContext} from 'react';
+import {ComponentRendererContext} from '@jahia/ui-extender';
+import * as PropTypes from 'prop-types';
 
-export default composeActions(
-    componentRendererAction,
-    {
-        init: context => {
-            context.enabled = context.mode === Constants.routes.baseCreateRoute;
-            context.addWarningBadge = Object.keys(context.formik.errors).length > 0;
-        },
-        onClick: async ({formik, renderComponent}) => {
-            if (!formik) {
-                return;
-            }
+const Create = ({context, render: Render, loading: Loading}) => {
+    const componentRenderer = useContext(ComponentRendererContext);
 
-            const formIsValid = await validateForm(formik, renderComponent);
-
-            if (formIsValid) {
-                return formik
-                    .submitForm()
-                    .then(() => {
-                        formik.resetForm(formik.values);
-                    });
-            }
-        }
+    if (Loading) {
+        return <Loading context={context}/>;
     }
-);
+
+    return (
+        <Render
+            context={{
+                ...context,
+                addWarningBadge: Object.keys(context.formik.errors).length > 0,
+                enabled: context.mode === Constants.routes.baseCreateRoute,
+                onClick: async ({formik}) => {
+                    const formIsValid = await validateForm(formik, componentRenderer);
+
+                    if (formIsValid) {
+                        return formik
+                            .submitForm()
+                            .then(() => {
+                                formik.resetForm(formik.values);
+                            });
+                    }
+                }
+            }}/>
+    );
+};
+
+Create.propTypes = {
+    context: PropTypes.object.isRequired,
+    render: PropTypes.func.isRequired,
+    loading: PropTypes.func
+};
+
+const createButtonAction = {
+    component: Create
+};
+
+export default createButtonAction;
+

--- a/src/javascript/Create/CreateForm/create.action.spec.js
+++ b/src/javascript/Create/CreateForm/create.action.spec.js
@@ -1,95 +1,61 @@
+import React, {useContext} from 'react';
+import {shallow} from '@jahia/test-framework';
 import createAction from './create.action';
 
+jest.mock('react', () => {
+    return {
+        ...jest.requireActual('react'),
+        useContext: jest.fn(() => ({}))
+    };
+});
+
 describe('create action', () => {
-    describe('onClick', () => {
-        let context;
-        beforeEach(() => {
-            context = {
+    let defaultProps;
+    let CreateAction;
+    beforeEach(() => {
+        CreateAction = createAction.component;
+        let render = jest.fn();
+        useContext.mockImplementation(() => ({render}));
+
+        defaultProps = {
+            context: {
                 formik: {
                     submitForm: jest.fn(() => Promise.resolve()),
-                    validateForm: jest.fn(() => Promise.resolve(context.formik.errors)),
+                    validateForm: jest.fn(() => Promise.resolve(defaultProps.context.formik.errors)),
                     resetForm: jest.fn(),
                     setFieldValue: jest.fn(),
                     setTouched: jest.fn(() => Promise.resolve()),
                     errors: {}
                 },
                 renderComponent: jest.fn()
-            };
-        });
-
-        it('should do nothing when formik is not available', async () => {
-            const context = {};
-
-            await createAction.onClick(context);
-
-            expect(Object.keys(context).length).toBe(0);
-        });
-
-        it('should submit form when formik is available', async () => {
-            await createAction.onClick(context);
-
-            expect(context.formik.submitForm).toHaveBeenCalled();
-        });
-
-        it('should not submit form when form is invalid', async () => {
-            context.formik = {
-                ...context.formik,
-                errors: {
-                    myFiled1: 'required',
-                    myFiled2: 'required'
-                }
-            };
-
-            await createAction.onClick(context);
-
-            expect(context.formik.submitForm).not.toHaveBeenCalled();
-        });
+            },
+            render: jest.fn(),
+            loading: undefined
+        };
     });
 
-    describe('onInit', () => {
-        let context;
-        const props = {};
-        beforeEach(() => {
-            context = {
-                formik: {
-                    errors: {}
-                }
-            };
-        });
+    it('should load when loading', async () => {
+        defaultProps.loading = () => 'Loading';
+        const cmp = shallow(<CreateAction {...defaultProps}/>);
+        expect(cmp.dive().debug()).toContain('Loading');
+    });
 
-        it('should enable create action when mode is create', () => {
-            context.mode = 'create';
+    it('should submit form when form is valid', async () => {
+        const cmp = shallow(<CreateAction {...defaultProps}/>);
+        await cmp.props().context.onClick(defaultProps.context);
+        expect(defaultProps.context.formik.submitForm).toHaveBeenCalled();
+    });
 
-            createAction.init(context, props);
-            expect(context.enabled).toBe(true);
-        });
-
-        it('should disable create action when mode is edit', () => {
-            context.mode = 'edit';
-
-            createAction.init(context, props);
-            expect(context.enabled).toBe(false);
-        });
-
-        it('should not add warn chip on button when all required fields were filled', () => {
-            createAction.init(context, props);
-
-            // As action expect impure function, testing params
-            expect(context.addWarningBadge).toBe(false);
-        });
-
-        it('should add warning badge on create button when required fields were not filled', () => {
-            context.formik = {
-                errors: {
-                    myFiled1: 'required',
-                    myFiled2: 'required'
-                }
-            };
-
-            createAction.init(context, props);
-
-            // As action expect impure function, testing params
-            expect(context.addWarningBadge).toBe(true);
-        });
+    it('should not submit form when form is invalid', async () => {
+        defaultProps.context.formik = {
+            ...defaultProps.context.formik,
+            errors: {
+                myFiled1: 'required',
+                myFiled2: 'required'
+            }
+        };
+        const cmp = shallow(<CreateAction {...defaultProps}/>);
+        await cmp.props().context.onClick(defaultProps.context);
+        expect(defaultProps.context.formik.submitForm).not.toHaveBeenCalled();
     });
 });

--- a/src/javascript/Validation/validation.utils.js
+++ b/src/javascript/Validation/validation.utils.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {SaveErrorModal} from './SaveModal/SaveErrorModal';
 
 const setErrorFieldTouched = (errorsFields, setTouched) => {
@@ -11,7 +10,7 @@ const setErrorFieldTouched = (errorsFields, setTouched) => {
     return setTouched(fieldsTouched);
 };
 
-export const validateForm = async ({setTouched, validateForm}, renderComponent) => {
+export const validateForm = async ({setTouched, validateForm}, componentRenderer) => {
     const errors = await validateForm();
     // SetEach values touched to display errors if there is so.
     // If no error, form will be reset after submition
@@ -21,14 +20,11 @@ export const validateForm = async ({setTouched, validateForm}, renderComponent) 
     const nbOfErrors = Object.keys(errors).length;
 
     if (nbOfErrors > 0) {
-        const handler = renderComponent(
-            <SaveErrorModal open
-                            nbOfErrors={nbOfErrors}
-                            onClose={() => {
-                                handler.setProps({open: false});
-                            }}/>
-        );
+        const onClose = () => {
+            componentRenderer.destroy('CopyLanguageDialog');
+        };
 
+        componentRenderer.render('SaveErrorModal', SaveErrorModal, {open: true, nbOfErrors, onClose});
         return false;
     }
 

--- a/src/javascript/Validation/validation.utils.spec.js
+++ b/src/javascript/Validation/validation.utils.spec.js
@@ -6,9 +6,11 @@ describe('validation utils', () => {
     describe('validateForm', () => {
         let formik;
         let renderComponent;
+        let render;
         let errors;
         beforeEach(() => {
-            renderComponent = jest.fn();
+            render = jest.fn();
+            renderComponent = {render};
             errors = {
                 field1: 'required',
                 field2: 'required'
@@ -37,15 +39,16 @@ describe('validation utils', () => {
             });
         });
 
-        it('should display a modal when field have erros', async () => {
+        it('should display a modal when field have errors', async () => {
             await validateForm(formik, renderComponent);
-            expect(renderComponent).toHaveBeenCalled();
+            expect(render).toHaveBeenCalled();
         });
 
-        it('should not display a modal when field have no erros', async () => {
+        it('should not display a modal when field have no errors', async () => {
             errors = {};
+            render = jest.fn();
             await validateForm(formik, renderComponent);
-            expect(renderComponent).not.toHaveBeenCalled();
+            expect(render).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-13066
Use new action framework for save and edit action
Remove usage of `componentRendererAction` from `react-material`

Covered by unit tests