### PR TITLE
BACKLOG-13053 : fix request publication button display for WIP contents

### DIFF
--- a/src/javascript/Edit/startWorkflow/startWorkflow.action.jsx
+++ b/src/javascript/Edit/startWorkflow/startWorkflow.action.jsx
@@ -1,5 +1,6 @@
 import {composeActions} from '@jahia/react-material';
 import {editRestrictedAction} from '~/actions/editRestricted.action';
+import {Constants} from '~/ContentEditor.constants';
 
 export default composeActions(
     editRestrictedAction,
@@ -16,6 +17,13 @@ export default composeActions(
                 if (context.enabled && (context.nodeData.lockedAndCannotBeEdited || context.formik.dirty)) {
                     context.disabled = true;
                 }
+
+                // Is WIP
+                const wipInfo = context.formik.values[Constants.wip.fieldName];
+                context.disabled =
+                    context.disabled ||
+                    wipInfo.status === Constants.wip.status.ALL_CONTENT ||
+                    (wipInfo.status === Constants.wip.status.LANGUAGES && wipInfo.languages.includes(context.language));
             } else {
                 // Is Visible
                 context.isVisible = context.enabled && context.nodeData.hasPublishPermission;

--- a/src/javascript/Edit/startWorkflow/startWorkflow.action.spec.js
+++ b/src/javascript/Edit/startWorkflow/startWorkflow.action.spec.js
@@ -1,4 +1,5 @@
 import startWorkflowAction from './startWorkflow.action';
+import {Constants} from '~/ContentEditor.constants';
 
 jest.mock('~/actions/redux.action', () => {
     let statemock;
@@ -88,7 +89,12 @@ describe('startWorkflow action', () => {
                     lockedAndCannotBeEdited: false
                 },
                 formik: {
-                    dirty: false
+                    dirty: false,
+                    values: {
+                        'WIP::Info': {
+                            status: 'DISABLED'
+                        }
+                    }
                 },
                 disabled: false
             };
@@ -136,6 +142,15 @@ describe('startWorkflow action', () => {
 
         it('should disable request publication action form is dirty', () => {
             context.formik.dirty = true;
+            startWorkflowAction.init(context);
+
+            expect(context.disabled).toBe(true);
+        });
+
+        it('should disable request publication action form is WIP', () => {
+            context.formik.values[Constants.wip.fieldName].status = Constants.wip.status.LANGUAGES;
+            context.formik.values[Constants.wip.fieldName].languages = ['en', 'fr'];
+            context.language = 'en';
             startWorkflowAction.init(context);
 
             expect(context.disabled).toBe(true);


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-13053

Make `Request publication` button disabled for `Work in progress` content.

Covered with Unit test