### PR TITLE
BACKLOG-13089: No display the "no preview badge" on page

### DIFF
--- a/src/javascript/EditPanel/EditPanelContent/PreviewContainer/Preview/ContentPreviewMemoWrapper.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/PreviewContainer/Preview/ContentPreviewMemoWrapper.jsx
@@ -64,7 +64,8 @@ const ContentPreviewMemoWrapperCmp = React.memo(({classes}) => {
         if (contentPreview) {
             removeSiblings(contentPreview);
             forceDisplay(contentPreview);
-        } else {
+        // Ce_preview-content id doesn't exist on page
+        } else if (!editorContext.nodeData.isPage) {
             setContentNotFound(true);
         }
     };

--- a/src/javascript/EditPanel/EditPanelContent/PreviewContainer/Preview/ContentPreviewMemoWrapper.spec.js
+++ b/src/javascript/EditPanel/EditPanelContent/PreviewContainer/Preview/ContentPreviewMemoWrapper.spec.js
@@ -21,15 +21,10 @@ jest.mock('@jahia/data-helper', () => {
     };
 });
 import {useContentPreview} from '@jahia/data-helper';
+import {useContentEditorContext} from '~/ContentEditor.context';
 
 jest.mock('~/ContentEditor.context', () => ({
-    useContentEditorContext: () => ({
-        path: '/site/digitall',
-        lang: 'fr',
-        nodeData: {
-            displayableNode: null
-        }
-    })
+    useContentEditorContext: jest.fn()
 }));
 
 jest.mock('./Preview.utils', () => {
@@ -49,6 +44,18 @@ jest.mock('./Preview.utils', () => {
 });
 
 describe('ContentPreviewMemoWrapper', () => {
+    let contentEditorContext;
+    beforeEach(() => {
+        contentEditorContext = {
+            path: '/site/digitall',
+            lang: 'fr',
+            nodeData: {
+                displayableNode: null
+            }
+        };
+        useContentEditorContext.mockImplementation(() => contentEditorContext);
+    });
+
     it('should display the preview with the provided path', () => {
         shallowWithTheme(
             <ContentPreviewMemoWrapper/>,
@@ -90,5 +97,21 @@ describe('ContentPreviewMemoWrapper', () => {
 
         PreviewComponent.props().domLoadedCallback(document);
         expect(cmp.find('DsBadge').exists()).toBe(true);
+    });
+
+    it('should not display the badge when content is not visible because it\'s a page', () => {
+        contentEditorContext.nodeData.isPage = true;
+        document.documentElement.innerHTML = '';
+        const cmp = shallowWithTheme(
+            <ContentPreviewMemoWrapper/>,
+            {},
+            dsGenericTheme
+        )
+            .dive();
+
+        const PreviewComponent = cmp.find({workspace: 'edit'});
+
+        PreviewComponent.props().domLoadedCallback(document);
+        expect(cmp.find('DsBadge').exists()).toBe(false);
     });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-13089

## Description

Page content have a preview but no id to "zoom" on it, so I not display the badge on page content

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
