### PR TITLE
QA-12727 : sync language between GWT and Content Editor

### DIFF
--- a/src/javascript/Api/ContentEditor.api.jsx
+++ b/src/javascript/Api/ContentEditor.api.jsx
@@ -47,7 +47,12 @@ const ContentEditorApiCmp = ({classes, client}) => {
      * @param uilang the preferred user lang for ui
      */
     window.CE_API.edit = (uuid, site, lang, uilang) => {
-        setEditorConfig({uuid, site, lang, uilang, mode: Constants.routes.baseEditRoute});
+        // Sync GWT language
+        if (window.top.authoringApi.switchLanguage) {
+            window.top.authoringApi.switchLanguage(lang);
+        }
+
+        setEditorConfig({uuid, site, lang, uilang, initLang: lang, mode: Constants.routes.baseEditRoute});
     };
 
     /**
@@ -66,9 +71,22 @@ const ContentEditorApiCmp = ({classes, client}) => {
      */
     // eslint-disable-next-line
     window.CE_API.create = (uuid, path, site, lang, uilang, nodeTypes, excludedNodeTypes, includeSubTypes) => {
+        // Sync GWT language
+        if (window.top.authoringApi.switchLanguage) {
+            window.top.authoringApi.switchLanguage(lang);
+        }
+
         if (nodeTypes && nodeTypes.length === 1 && !includeSubTypes) {
             // Direct create with a known content type
-            setEditorConfig({uuid, site, lang, uilang, contentType: nodeTypes[0], mode: Constants.routes.baseCreateRoute});
+            setEditorConfig({
+                uuid,
+                site,
+                lang,
+                uilang,
+                initLang: lang,
+                contentType: nodeTypes[0],
+                mode: Constants.routes.baseCreateRoute
+            });
         } else {
             getCreatableNodetypes(
                 client,
@@ -86,6 +104,7 @@ const ContentEditorApiCmp = ({classes, client}) => {
                             site,
                             lang,
                             uilang,
+                            initLang: lang,
                             contentType: creatableNodeTypes[0].name,
                             mode: Constants.routes.baseCreateRoute
                         });
@@ -109,6 +128,11 @@ const ContentEditorApiCmp = ({classes, client}) => {
     };
 
     const closeAll = () => {
+        // Restore GWT language
+        if (window.top.authoringApi.switchLanguage) {
+            window.top.authoringApi.switchLanguage(editorConfig.initLang);
+        }
+
         setEditorConfig(false);
         setContentTypeSelectorConfig(false);
     };
@@ -140,9 +164,8 @@ const ContentEditorApiCmp = ({classes, client}) => {
             // Redirect to CE edit mode, for the created node
             if (editorConfig) {
                 setEditorConfig({
+                    ...editorConfig,
                     uuid: createdNodeUuid,
-                    site: editorConfig.site,
-                    uilang: editorConfig.uilang,
                     lang: lang ? lang : editorConfig.lang,
                     mode: Constants.routes.baseEditRoute
                 });
@@ -161,12 +184,8 @@ const ContentEditorApiCmp = ({classes, client}) => {
             // Update the lang of current opened CE
             if (editorConfig) {
                 setEditorConfig({
-                    uuid: editorConfig.uuid,
-                    site: editorConfig.site,
-                    uilang: editorConfig.uilang,
-                    lang: lang,
-                    mode: editorConfig.mode,
-                    contentType: editorConfig.contentType
+                    ...editorConfig,
+                    lang: lang
                 });
             }
         }
@@ -222,6 +241,7 @@ const ContentEditorApiCmp = ({classes, client}) => {
                         uuid: contentTypeSelectorConfig.uuid,
                         site: contentTypeSelectorConfig.site,
                         uilang: contentTypeSelectorConfig.uilang,
+                        initLang: contentTypeSelectorConfig.lang,
                         lang: contentTypeSelectorConfig.lang,
                         contentType: contentType.name,
                         mode: Constants.routes.baseCreateRoute

--- a/src/javascript/ContentEditor.redux.jsx
+++ b/src/javascript/ContentEditor.redux.jsx
@@ -17,6 +17,11 @@ const mapStateToProps = state => {
 const ContentEditorReduxCmp = ({mode, uuid, lang, uilang, site, contentType}) => {
     const {redirect, hasHistory, exit, registerBlockListener, unRegisterBlockListener} = useContentEditorHistory();
     const {t} = useTranslation();
+    // Sync GWT language
+    if (window.top.authoringApi.switchLanguage) {
+        window.top.authoringApi.switchLanguage(lang);
+    }
+
     const envProps = {
         setUrl: (mode, language, uuid, contentType) => redirect({mode, language, uuid, rest: contentType}),
         back: exit,

--- a/src/javascript/ContentEditorHistory/ContentEditorHistory.jsx
+++ b/src/javascript/ContentEditorHistory/ContentEditorHistory.jsx
@@ -11,7 +11,7 @@ export const useContentEditorHistory = () => {
         const currentPath = history.location.pathname;
         const {appName, currentLanguage, currentMode, currentUuid, currentRest} = splitPath(currentPath);
         if (appName !== Constants.appName) {
-            setStoredLocation(history.location);
+            setStoredLocation({location: history.location, language: language || currentLanguage});
         }
 
         // Compute rest (end of the path)
@@ -29,12 +29,17 @@ export const useContentEditorHistory = () => {
     };
 
     const exit = () => {
+        // Restore GWT language
+        if (window.top.authoringApi.switchLanguage) {
+            window.top.authoringApi.switchLanguage(storedLocation.language);
+        }
+
         // In order use:
         // - Stored location
         // - Referer
         // - Back button
-        if (storedLocation) {
-            history.push(storedLocation.pathname + storedLocation.search);
+        if (storedLocation.location) {
+            history.push(storedLocation.location.pathname + storedLocation.location.search);
         } else if (document.referer) {
             window.history.push(document.referer);
         } else {

--- a/src/javascript/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
+++ b/src/javascript/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
@@ -19,7 +19,9 @@ const EditPanelLanguageSwitcher = ({siteInfo, formik}) => {
         }
 
         // Switch edit mode linker language
-        window.parent.authoringApi.switchLanguage(language);
+        if (window.top.authoringApi.switchLanguage) {
+            window.top.authoringApi.switchLanguage(language);
+        }
     };
 
     return (


### PR DESCRIPTION
https://jira.jahia.org/browse/QA-12727
This sync GWT (old edit engines) language and content editor.

- Language use for GWT context is the one used to open Content Editor.
- We restore the GWT language to the one that was used to open content editor when editor is closed. 

Covered by integration test.
