### PR TITLE
BACKLOG-12906 : fix permission check and make components work properl…

### DIFF
--- a/src/javascript/ContentEditor.context.js
+++ b/src/javascript/ContentEditor.context.js
@@ -26,7 +26,8 @@ export const withContentEditorDataContextProvider = (formQuery, formDataAdapter)
             uuid,
             language: lang,
             uilang: Constants.supportedLocales.includes(uilang) ? uilang : Constants.defaultLocale,
-            primaryNodeType: contentType
+            primaryNodeType: contentType,
+            writePermission: `jcr:modifyProperties_default_${lang}`
         };
         const {loading, error, errorMessage, data: formDefinition, refetch: refetchFormData} = useFormDefinition(formQuery, formQueryParams, formDataAdapter, t);
         const {nodeData, initialValues, details, technicalInfo, sections, title, nodeTypeName} = formDefinition || {};

--- a/src/javascript/Edit/Edit.actions.js
+++ b/src/javascript/Edit/Edit.actions.js
@@ -15,7 +15,6 @@ export const registerEditActions = actionsRegistry => {
         buttonLabel: 'content-editor:label.contentEditor.edit.contentEdit',
         targets: ['contentActions:2'],
         hideOnNodeTypes: ['jnt:virtualsite'],
-        requiredPermission: ['jcr:modifyProperties'],
         getDisplayName: true
     });
 

--- a/src/javascript/Edit/EditForm.gql-queries.js
+++ b/src/javascript/Edit/EditForm.gql-queries.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import {NodeDataFragment} from '~/NodeData/NodeData.gql-queries';
 
 export const FormQuery = gql`
-    query editForm($uilang:String!, $language:String!, $uuid: String!) {
+    query editForm($uilang:String!, $language:String!, $uuid: String!, $writePermission: String!) {
         forms {
             editForm(uiLocale: $uilang, locale: $language, uuidOrPath: $uuid) {
                 name

--- a/src/javascript/Edit/copyLanguage/copyLanguage.action.jsx
+++ b/src/javascript/Edit/copyLanguage/copyLanguage.action.jsx
@@ -10,7 +10,7 @@ export const CopyLanguageActionComponent = ({context, render: Render}) => {
     return (
         <Render context={{
             ...context,
-            enabled: context.siteInfo.languages.length > 1,
+            enabled: context.siteInfo.languages.length > 1 && context.nodeData.hasWritePermission,
             onClick: () => {
                 render('CopyLanguageDialog', CopyLanguageDialog, {
                     isOpen: true,

--- a/src/javascript/Edit/copyLanguage/copyLanguage.action.spec.jsx
+++ b/src/javascript/Edit/copyLanguage/copyLanguage.action.spec.jsx
@@ -18,7 +18,8 @@ describe('copy language action', () => {
             context: {
                 mode: 'edit',
                 nodeData: {
-                    uuid: '12345-321456-1234565789'
+                    uuid: '12345-321456-1234565789',
+                    hasWritePermission: true
                 },
                 language: 'fr',
                 siteInfo: {
@@ -30,6 +31,17 @@ describe('copy language action', () => {
             },
             render: () => ''
         };
+    });
+
+    it('should render not be enabled when the user has no write access', () => {
+        defaultProps.context.nodeData.hasWritePermission = false;
+        const cmp = shallowWithTheme(
+            <CopyLanguageActionComponent {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+
+        expect(cmp.props().context.enabled).toBeFalsy();
     });
 
     it('should render be enabled when there is more than one language', () => {

--- a/src/javascript/Edit/save/save.request.js
+++ b/src/javascript/Edit/save/save.request.js
@@ -45,7 +45,8 @@ export const saveNode = ({
                 variables: {
                     uuid: nodeData.uuid,
                     language,
-                    uilang: uilang
+                    uilang: uilang,
+                    writePermission: `jcr:modifyProperties_default_${language}`
                 }
             },
             {

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/FieldSet.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/FieldSet.jsx
@@ -39,7 +39,7 @@ const FieldSetCmp = ({fieldset, classes, formik: {values, handleChange}}) => {
                 <Toggle data-sel-role-dynamic-fieldset={fieldset.name}
                         id={fieldset.name}
                         checked={activatedFieldSet}
-                        readOnly={context.nodeData.lockedAndCannotBeEdited}
+                        readOnly={context.nodeData.lockedAndCannotBeEdited || !context.nodeData.hasWritePermission}
                         onChange={handleChange}
                 />}
 

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/FieldSet.spec.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/FieldSet.spec.jsx
@@ -36,7 +36,8 @@ describe('FieldSet component', () => {
             }
         ],
         nodeData: {
-            lockedAndCannotBeEdited: false
+            lockedAndCannotBeEdited: false,
+            hasWritePermission: true
         }
     };
 
@@ -105,6 +106,26 @@ describe('FieldSet component', () => {
     it('should display readOnly toggle for dynamic FieldSet when editor is locked', () => {
         let overridedContext = context;
         overridedContext.nodeData.lockedAndCannotBeEdited = true;
+        setContext(overridedContext);
+        props.fieldset.dynamic = true;
+
+        const cmp = shallowWithTheme(
+            <FieldSet {...props}/>,
+            {},
+            dsGenericTheme
+        )
+            .dive()
+            .dive()
+            .dive();
+
+        const toggleCmp = cmp.find('WithStyles(ToggleCmp)');
+        expect(toggleCmp.exists()).toBe(true);
+        expect(toggleCmp.props().readOnly).toBe(true);
+    });
+
+    it('should display readOnly toggle for dynamic FieldSet when editor has no write permission', () => {
+        let overridedContext = context;
+        overridedContext.nodeData.hasWritePermission = false;
         setContext(overridedContext);
         props.fieldset.dynamic = true;
 

--- a/src/javascript/EditPanel/WorkInProgress/OpenWorkInProgressModal.action.jsx
+++ b/src/javascript/EditPanel/WorkInProgress/OpenWorkInProgressModal.action.jsx
@@ -47,6 +47,7 @@ export const OpenWorkInProgressModal = ({context, render: Render, ...props}) => 
                 {...(context.displayActionProps || {})}
                 context={{
                     ...context,
+                    enabled: context.nodeData.hasWritePermission,
                     onClick: singleLanguage ? switchButton : openModal
                 }}/>
         </>

--- a/src/javascript/EditPanel/WorkInProgress/OpenWorkInProgressModal.action.spec.js
+++ b/src/javascript/EditPanel/WorkInProgress/OpenWorkInProgressModal.action.spec.js
@@ -24,6 +24,9 @@ describe('WorkInProgressDialog', () => {
                     values: {
                         'WIP::Info': {}
                     }
+                },
+                nodeData: {
+                    hasWritePermission: true
                 }
             },
             otherProps: true,
@@ -34,6 +37,17 @@ describe('WorkInProgressDialog', () => {
             render: jest.fn()
         };
         React.useContext.mockImplementation(() => componentRenderer);
+    });
+
+    it('should be disbabled if no write permission', () => {
+        defaultProps.context.nodeData.hasWritePermission = false;
+        const cmp = shallowWithTheme(
+            <OpenWorkInProgressModal {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+
+        expect(cmp.find('render').props().context.enabled).toBe(false);
     });
 
     it('should pass otherProps to the render component', () => {

--- a/src/javascript/NodeData/NodeData.gql-queries.js
+++ b/src/javascript/NodeData/NodeData.gql-queries.js
@@ -6,7 +6,8 @@ const NodeDataFragment = {
         variables: {
             uilang: 'String!',
             language: 'String!',
-            uuid: 'String!'
+            uuid: 'String!',
+            writePermission: 'String!'
         },
         applyFor: 'node',
         gql: gql`fragment NodeData on JCRQuery {
@@ -56,6 +57,7 @@ const NodeDataFragment = {
                     values
                     notZonedDateValues
                 }
+                hasWritePermission: hasPermission(permissionName: $writePermission)
                 hasPublishPermission: hasPermission(permissionName: "publish")
                 hasStartPublicationWorkflowPermission: hasPermission(permissionName: "publication-start")
                 lockInfo {


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-12906
- Always display edit button
- Use i18n permission name to check write access
- make component disabled when no write access

Covered with unit and integration tests