### PR TITLE
BACKLOG-12893: sort all column of the picker when in list view

### DIFF
--- a/src/javascript/DesignSystem/ContentTable/ContentTable.jsx
+++ b/src/javascript/DesignSystem/ContentTable/ContentTable.jsx
@@ -53,7 +53,7 @@ const styles = theme => ({
     }
 });
 
-const ContentTable = ({
+const ContentTableCmp = ({
     data,
     order,
     orderBy,
@@ -64,7 +64,8 @@ const ContentTable = ({
     onSelect,
     initialSelection,
     hasMore,
-    loadMore
+    loadMore,
+    onSort
 }) => {
     const [selection, setSelection] = useState(
         initialSelection
@@ -99,10 +100,11 @@ const ContentTable = ({
                 >
                     <Table className={classes.table} aria-labelledby="tableTitle">
                         <ContentTableHeader
-                    columns={columns}
-                    order={order}
-                    orderBy={orderBy}
-                />
+                            columns={columns}
+                            order={order}
+                            orderBy={orderBy}
+                            onSort={onSort}
+                        />
                         {data && data.length === 0 ?
                             <EmptyTable labelEmpty={labelEmpty}/> :
                             <TableBody>
@@ -146,15 +148,16 @@ const ContentTable = ({
     );
 };
 
-ContentTable.defaultProps = {
+ContentTableCmp.defaultProps = {
     isMultipleSelectable: false,
     onSelect: () => {},
     initialSelection: [],
     hasMore: false,
-    loadMore: () => {}
+    loadMore: () => {},
+    onSort: null
 };
 
-ContentTable.propTypes = {
+ContentTableCmp.propTypes = {
     data: PropTypes.PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
@@ -172,7 +175,9 @@ ContentTable.propTypes = {
     onSelect: PropTypes.func,
     initialSelection: PropTypes.array,
     hasMore: PropTypes.bool,
-    loadMore: PropTypes.func
+    loadMore: PropTypes.func,
+    onSort: PropTypes.func
 };
 
-export default withStyles(styles)(ContentTable);
+export const ContentTable = withStyles(styles)(ContentTableCmp);
+ContentTable.displayName = 'ContentTable';

--- a/src/javascript/DesignSystem/ContentTable/ContentTable.spec.js
+++ b/src/javascript/DesignSystem/ContentTable/ContentTable.spec.js
@@ -1,7 +1,7 @@
 import {dsGenericTheme} from '@jahia/design-system-kit';
 import {shallowWithTheme} from '@jahia/test-framework';
 import React from 'react';
-import ContentTable from './ContentTable';
+import {ContentTable} from './';
 
 describe('ContentTable', () => {
     let defaultProps;

--- a/src/javascript/DesignSystem/ContentTable/ContentTableHeader/ContentTableHeader.jsx
+++ b/src/javascript/DesignSystem/ContentTable/ContentTableHeader/ContentTableHeader.jsx
@@ -5,7 +5,7 @@ import TableSortLabel from '@material-ui/core/TableSortLabel';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const ContentTableHeader = ({columns, order, orderBy}) => {
+const ContentTableHeader = ({columns, order, orderBy, onSort}) => {
     return (
         <TableHead>
             <TableRow>
@@ -17,10 +17,8 @@ const ContentTableHeader = ({columns, order, orderBy}) => {
                                sortDirection={orderBy === column.property ? order : false}
                     >
                         <TableSortLabel active={orderBy === column.property}
-                                        direction={order}
-                                        onClick={() => {
-                                            // TODO: handle sort
-                                        }}
+                                        direction={order.toLowerCase()}
+                                        onClick={() => onSort(column)}
                         >
                             {column.label}
                         </TableSortLabel>
@@ -31,13 +29,18 @@ const ContentTableHeader = ({columns, order, orderBy}) => {
     );
 };
 
+ContentTableHeader.defaultProps = {
+    onSort: () => {}
+};
+
 ContentTableHeader.propTypes = {
     columns: PropTypes.PropTypes.arrayOf(PropTypes.shape({
         property: PropTypes.string.isRequired,
         label: PropTypes.string.isRequired
     })).isRequired,
     order: PropTypes.string.isRequired,
-    orderBy: PropTypes.string.isRequired
+    orderBy: PropTypes.string.isRequired,
+    onSort: PropTypes.func
 };
 
 export {ContentTableHeader};

--- a/src/javascript/DesignSystem/ContentTable/index.js
+++ b/src/javascript/DesignSystem/ContentTable/index.js
@@ -1,1 +1,1 @@
-export {default as ContentTable} from './ContentTable';
+export * from './ContentTable';

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Picker/PickerDialog/Views/List/List.spec.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Picker/PickerDialog/Views/List/List.spec.jsx
@@ -15,7 +15,7 @@ jest.mock('@apollo/react-hooks', () => {
     };
 });
 
-import {setQueryResult} from '@apollo/react-hooks';
+import {setQueryResult, useQuery} from '@apollo/react-hooks';
 import {List} from './List';
 
 const queryResult = {
@@ -116,6 +116,7 @@ describe('PickerDialog - List view', () => {
         window.contextJsParameters = {
             contextPath: ''
         };
+        useQuery.mockClear();
     });
 
     it('should display the ContentTable', () => {
@@ -131,7 +132,7 @@ describe('PickerDialog - List view', () => {
             dsGenericTheme
         );
 
-        cmp.find('WithStyles(ContentTable)').exists();
+        cmp.find('ContentTable').exists();
     });
 
     it('should display the name of content', () => {
@@ -146,7 +147,7 @@ describe('PickerDialog - List view', () => {
             {},
             dsGenericTheme
         )
-            .find('WithStyles(ContentTable)');
+            .find('ContentTable');
 
         expect(cmp.props().data[0].name).toContain('Home');
     });
@@ -163,7 +164,7 @@ describe('PickerDialog - List view', () => {
             {},
             dsGenericTheme
         )
-            .find('WithStyles(ContentTable)');
+            .find('ContentTable');
 
         expect(cmp.props().data[0].type).toContain('Page');
     });
@@ -180,7 +181,7 @@ describe('PickerDialog - List view', () => {
             {},
             dsGenericTheme
         )
-            .find('WithStyles(ContentTable)');
+            .find('ContentTable');
 
         expect(cmp.props().columns[1].property).toContain('type');
         expect(cmp.props().data[0].subContentsCount).toBeUndefined();
@@ -198,7 +199,7 @@ describe('PickerDialog - List view', () => {
             {},
             dsGenericTheme
         )
-            .find('WithStyles(ContentTable)');
+            .find('ContentTable');
 
         expect(cmp.props().columns[1].property).toContain('subContentsCount');
         expect(cmp.props().data[0].subContentsCount).toBe(5);
@@ -216,7 +217,7 @@ describe('PickerDialog - List view', () => {
             {},
             dsGenericTheme
         )
-            .find('WithStyles(ContentTable)');
+            .find('ContentTable');
 
         expect(cmp.props().columns[5].property).toBe('navigateInto');
         expect(cmp.props().data[0].navigateInto).toBe(true);
@@ -234,7 +235,7 @@ describe('PickerDialog - List view', () => {
             {},
             dsGenericTheme
         )
-            .find('WithStyles(ContentTable)');
+            .find('ContentTable');
 
         expect(cmp.props().data[1].navigateInto).toBe(false);
     });
@@ -251,7 +252,7 @@ describe('PickerDialog - List view', () => {
             {},
             dsGenericTheme
         )
-            .find('WithStyles(ContentTable)');
+            .find('ContentTable');
 
         cmp.props().data[0].props.navigateInto.onClick({preventDefault: () => {}});
         expect(defaultProps.setSelectedPath).toHaveBeenCalledWith('/sites/mySite/home');
@@ -276,5 +277,55 @@ describe('PickerDialog - List view', () => {
             .dive();
 
         expect(cmp.debug()).toContain('10 items found');
+    });
+
+    it('should sort List with lastModified by default', () => {
+        shallowWithTheme(
+            <List {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+
+        expect(useQuery).toHaveBeenCalled();
+        expect(useQuery.mock.calls[0][1].variables.fieldSorter).toEqual({
+            fieldName: 'lastModified.value',
+            sortType: 'DESC'
+        });
+    });
+
+    it('should sort List with displayName when sort the name column', () => {
+        const cmp = shallowWithTheme(
+            <List {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+
+        cmp.find('ContentTable').simulate('sort', {
+            property: 'name'
+        });
+
+        expect(useQuery).toHaveBeenCalled();
+        expect(useQuery.mock.calls[1][1].variables.fieldSorter).toEqual({
+            fieldName: 'displayName',
+            sortType: 'DESC'
+        });
+    });
+
+    it('should sort List with lastModified asc when reclicking on the column', () => {
+        const cmp = shallowWithTheme(
+            <List {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+
+        cmp.find('ContentTable').simulate('sort', {
+            property: 'lastModified'
+        });
+
+        expect(useQuery).toHaveBeenCalled();
+        expect(useQuery.mock.calls[1][1].variables.fieldSorter).toEqual({
+            fieldName: 'lastModified.value',
+            sortType: 'ASC'
+        });
     });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

https://jira.jahia.org/browse/BACKLOG-12893:

## Description

Sort content editor pickers

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [ ] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [x] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
