### PR TITLE
BACKLOG-13364 : avoid to reload Content Editor many times

### DIFF
--- a/src/javascript/Edit/Edit.jsx
+++ b/src/javascript/Edit/Edit.jsx
@@ -53,6 +53,7 @@ export const EditCmp = ({
     return (
         <PublicationInfoContextProvider uuid={nodeData.uuid} lang={lang}>
             <Formik
+                enableReinitialize
                 initialValues={initialValues}
                 render={props => <EditPanel {...props} title={title}/>}
                 validate={validate(sections)}

--- a/src/javascript/FormDefinitions/FormDefinitions.js
+++ b/src/javascript/FormDefinitions/FormDefinitions.js
@@ -3,7 +3,7 @@ import {useQuery} from '@apollo/react-hooks';
 export const useFormDefinition = (query, queryParams, adapter, t) => {
     const {loading, error, data, refetch} = useQuery(query, {
         variables: queryParams,
-        fetchPolicy: 'cache-and-network'
+        fetchPolicy: 'cache-first'
     });
 
     if (error || loading || !data.jcr) {


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-13364
This to avoid Content Editor to be re rendered multiple times.
