### PR TITLE
BACKGLOG-13711 : handle value constraints correctly when overriding w…

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormFieldValue.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormFieldValue.java
@@ -137,6 +137,11 @@ public class EditorFormFieldValue {
         return type;
     }
 
+    public String getValue() {
+        // Allows ObjectMapper to correctly fill the field when customizing constraint value with json file
+        return value;
+    }
+
     @Override
     public String toString() {
         return "EditorFormFieldValue{type='" + type + '\''+ ", value='" + value + '\'' + '}';

--- a/src/test/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImplTest.java
+++ b/src/test/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImplTest.java
@@ -361,6 +361,50 @@ public class EditorFormServiceImplTest extends AbstractJUnitTest {
         Assert.isTrue(!hasFieldSet(newForm, "metadata", "jmix:tagged"), "cannot find jmix:tagged in metadata section");
     }
 
+    /**
+     * Given I define a JSON override a field to add a value constraints
+     * <p>
+     * When the API for a content type is called
+     * <p>
+     * Then the API will take the override into account and return the JSON with the fieldset in the right itemType
+     * <p>
+     * Fields can also support value constraint : "valueConstraints": [
+     *         {
+     *           "value": {
+     *             "type": "String",
+     *             "value": "myConstraint"
+     *           },
+     *           "displayValue": "myConstraint"
+     *         }
+     *       ]
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAddFieldWithValueConstraintOverride() throws Exception {
+        EditorForm form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
+        staticDefinitionsRegistry.readEditorFormFieldSet(getResource("META-INF/jahia-content-editor-forms/overrides/fieldSets/jmix_description_value_constraint.json"));
+        // test that description is in jmix:description
+        Assert.isTrue(hasField(form, "metadata", "jmix:description", "jcr:description"), "cannot find jcr:description field "
+            + "jmix:description fieldset in metadata section");
+
+        EditorForm newForm = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
+        // Field contains a value constraint
+        List<EditorFormFieldValueConstraint> valueConstraints = getValueConstraints(newForm, "metadata", "jmix:description", "jcr:description");
+
+        Assert.isTrue(valueConstraints
+            .stream()
+            .anyMatch(valueConstraint -> valueConstraint.getDisplayValue().equals("myConstraint"))
+        , "The value" + valueConstraints.get(0).getDisplayValue());
+    }
+
+    private List<EditorFormFieldValueConstraint> getValueConstraints(final EditorForm form, final String searchedSection,
+        final String searchedFieldSet,
+        final String searchedField){
+        EditorFormField field = getField(form, searchedSection, searchedFieldSet, searchedField);
+        return field.getValueConstraints();
+    }
+
     @Test
     public void testUnstructuredFieldSetOverride() throws Exception {
         staticDefinitionsRegistry.readEditorFormFieldSet(getResource("META-INF/jahia-content-editor-forms/overrides/fieldSets/jnt_unstructuredNews.json"));

--- a/src/test/resources/META-INF/jahia-content-editor-forms/overrides/fieldSets/jmix_description_value_constraint.json
+++ b/src/test/resources/META-INF/jahia-content-editor-forms/overrides/fieldSets/jmix_description_value_constraint.json
@@ -1,0 +1,20 @@
+{
+  "name": "jmix:description",
+  "displayName": "Description",
+  "description": "",
+  "dynamic": true,
+  "fields": [
+    {
+      "name": "jcr:description",
+      "valueConstraints": [
+        {
+          "value": {
+            "type": "String",
+            "value": "myConstraint"
+          },
+          "displayValue": "myConstraint"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
…ith json

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-13711

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [X] Unit Tests (Most changes _should_ have unit tests)
