### PR TITLE
BACKLOG-13915 : trigger onChange when a selector is removed from the DOM

### DIFF
--- a/src/javascript/AddMixin.register.js
+++ b/src/javascript/AddMixin.register.js
@@ -10,8 +10,8 @@ export const registerAddMixin = registry => {
                 editorSection = helper.moveMixinToInitialFieldset(previousMixin, editorContext.sections, editorContext.formik);
             }
 
-            const currentValueProperty = currentValue.properties.find(entry => entry.name === 'addMixin');
-            const addedMixin = currentValueProperty ? currentValueProperty.value : null;
+            const currentValueProperty = currentValue?.properties.find(entry => entry.name === 'addMixin');
+            const addedMixin = currentValueProperty?.value;
             if (addedMixin) {
                 editorSection = helper.moveMixinToTargetFieldset(addedMixin, field.nodeType, editorSection, field, editorContext.formik);
             }

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/MultipleField.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/MultipleField.jsx
@@ -1,7 +1,7 @@
 import {Button, IconButton} from '@jahia/design-system-kit';
 import {withStyles} from '@material-ui/core';
 import {Close} from '@material-ui/icons';
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import * as PropTypes from 'prop-types';
 import {compose} from '~/utils';
 import {useTranslation} from 'react-i18next';
@@ -26,6 +26,10 @@ export const MultipleFieldCmp = ({classes, inputContext, field, onChange, formik
     const {t} = useTranslation();
     const [isInit, setInit] = useState(false);
     const [data, setData] = useState(values[field.name] ? new Array(values[field.name].length) : []);
+
+    useEffect(() => {
+        return () => onChange(_mapDataForOnChange(data), undefined);
+    }, []);
 
     const _mapDataForOnChange = dataToMap => {
         return dataToMap.filter(item => item.data !== undefined).map(item => item.data);
@@ -137,6 +141,8 @@ export const MultipleFieldCmp = ({classes, inputContext, field, onChange, formik
                                                                            }}
                                                                            onInit={initData => {
                                                                                multipleFieldOnInit(initData, index);
+                                                                           }}
+                                                                           onDestroy={() => {
                                                                            }}
                                                            />
                                                        );

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Category/Category.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Category/Category.jsx
@@ -8,7 +8,7 @@ import {ProgressOverlay} from '@jahia/react-material';
 import {useTranslation} from 'react-i18next';
 import {adaptToCategoryTree} from './category.adapter';
 
-const Category = ({field, value, id, editorContext, onChange, onInit}) => {
+const Category = ({field, value, id, editorContext, onChange, onInit, onDestroy}) => {
     const {t} = useTranslation();
     const {data, error, loading} = useQuery(GetCategories, {
         variables: {
@@ -32,7 +32,9 @@ const Category = ({field, value, id, editorContext, onChange, onInit}) => {
         if (data) {
             onInit(generateValuesFromUuid(value));
         }
-    }, [value, data]);
+
+        return () => data && onDestroy(generateValuesFromUuid);
+    }, [data]);
 
     if (error) {
         const message = t(
@@ -75,7 +77,8 @@ Category.propTypes = {
         lang: PropTypes.string.isRequired
     }).isRequired,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };
 
 export default Category;

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Category/Category.spec.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Category/Category.spec.jsx
@@ -17,10 +17,14 @@ jest.mock('@apollo/react-hooks', () => {
     };
 });
 
+let useEffect;
+
 jest.mock('react', () => {
     return {
         ...jest.requireActual('react'),
-        useEffect: cb => cb()
+        useEffect: cb => {
+            useEffect = cb();
+        }
     };
 });
 
@@ -28,11 +32,13 @@ describe('Category component', () => {
     let props;
     const onChange = jest.fn();
     const onInit = jest.fn();
+    const onDestroy = jest.fn();
 
     beforeEach(() => {
         props = {
             onChange,
             onInit,
+            onDestroy,
             id: 'Category',
             field: {
                 displayName: 'Categories',
@@ -88,6 +94,12 @@ describe('Category component', () => {
     it('should onInit called when render the element', () => {
         buildComp(props);
         expect(onInit).toHaveBeenCalled();
+    });
+
+    it('should onDestroy called when element detached the element', () => {
+        buildComp(props).unmount();
+        useEffect();
+        expect(onDestroy).toHaveBeenCalled();
     });
 
     it('should onChange called when modify an element', () => {

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Checkbox/Checkbox.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Checkbox/Checkbox.jsx
@@ -3,10 +3,11 @@ import * as PropTypes from 'prop-types';
 import {Toggle} from '@jahia/design-system-kit';
 import {FieldPropTypes} from '~/FormDefinitions/FormData.proptypes';
 
-const Checkbox = ({field, value, id, onChange, onInit}) => {
+const Checkbox = ({field, value, id, onChange, onInit, onDestroy}) => {
     useEffect(() => {
         onInit(value);
-    }, [value]);
+        return () => onDestroy();
+    }, []);
 
     return (
         <Toggle id={id}
@@ -25,7 +26,8 @@ Checkbox.propTypes = {
     id: PropTypes.string.isRequired,
     value: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };
 
 export default Checkbox;

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/ChoiceList/MultipleSelect/MultipleSelect.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/ChoiceList/MultipleSelect/MultipleSelect.jsx
@@ -3,7 +3,7 @@ import {MultipleInput} from '~/DesignSystem/MultipleInput';
 import PropTypes from 'prop-types';
 import {FieldPropTypes} from '~/FormDefinitions/FormData.proptypes';
 
-const MultipleSelect = ({field, id, value, setActionContext, onChange, onInit}) => {
+const MultipleSelect = ({field, id, value, setActionContext, onChange, onInit, onDestroy}) => {
     const findValues = value => field.valueConstraints.filter(item => value?.includes(item.value.string));
 
     const multipleSelectOnChange = newValues => {
@@ -12,6 +12,10 @@ const MultipleSelect = ({field, id, value, setActionContext, onChange, onInit}) 
 
     useEffect(() => {
         onInit(findValues(value));
+        return () => onDestroy();
+    }, []);
+
+    useEffect(() => {
         setActionContext(prevActionContext => ({
             initialized: true,
             contextHasChange: !prevActionContext.initialized ||
@@ -46,7 +50,8 @@ MultipleSelect.propTypes = {
     value: PropTypes.arrayOf(PropTypes.string),
     setActionContext: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };
 
 export default MultipleSelect;

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/ChoiceList/MultipleSelect/MultipleSelect.spec.js
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/ChoiceList/MultipleSelect/MultipleSelect.spec.js
@@ -4,15 +4,28 @@ import {shallowWithTheme} from '@jahia/test-framework';
 import MultipleSelect from './MultipleSelect';
 import {dsGenericTheme} from '@jahia/design-system-kit';
 
+let mockUseEffect = [];
+
+jest.mock('react', () => {
+    return {
+        ...jest.requireActual('react'),
+        useEffect: cb => {
+            mockUseEffect.push(cb());
+        }
+    };
+});
+
 describe('MultipleSelect component', () => {
     let props;
     let onChange = jest.fn();
     let onInit = jest.fn();
+    const onDestroy = jest.fn();
 
     beforeEach(() => {
         props = {
             onChange,
             onInit,
+            onDestroy,
             id: 'MultipleSelect1',
             field: {
                 name: 'myOption',
@@ -45,6 +58,14 @@ describe('MultipleSelect component', () => {
         const cmp = buildComp(props);
 
         expect(cmp.props().id).toBe(props.id);
+    });
+
+    it('should onDestroy called when element detached the element', () => {
+        const cmp = buildComp(props, ['yoloooFR']);
+        cmp.unmount();
+        // Check only first useEffect called
+        mockUseEffect[0]();
+        expect(onDestroy).toHaveBeenCalled();
     });
 
     it('should display each option given', () => {

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/ChoiceList/SingleSelect/SingleSelect.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/ChoiceList/SingleSelect/SingleSelect.jsx
@@ -18,11 +18,15 @@ const styles = theme => ({
     }
 });
 
-export const SingleSelectCmp = ({classes, field, value, id, setActionContext, onChange, onInit}) => {
+export const SingleSelectCmp = ({classes, field, value, id, setActionContext, onChange, onInit, onDestroy}) => {
     const singleSelectOnChange = newValue => field.valueConstraints.find(item => item.value.string === newValue);
 
     useEffect(() => {
         onInit(singleSelectOnChange(value));
+        return () => onDestroy(singleSelectOnChange);
+    }, []);
+
+    useEffect(() => {
         setActionContext(prevActionContext => ({
             initialized: true,
             contextHasChange: !prevActionContext.initialized ||
@@ -66,7 +70,8 @@ SingleSelectCmp.propTypes = {
     classes: PropTypes.object.isRequired,
     setActionContext: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };
 
 const SingleSelect = withStyles(styles)(SingleSelectCmp);

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/ChoiceList/SingleSelect/SingleSelect.spec.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/ChoiceList/SingleSelect/SingleSelect.spec.jsx
@@ -4,14 +4,27 @@ import {shallowWithTheme} from '@jahia/test-framework';
 import {dsGenericTheme} from '@jahia/design-system-kit';
 import {SingleSelectCmp} from './SingleSelect';
 
+let mockUseEffect = [];
+
+jest.mock('react', () => {
+    return {
+        ...jest.requireActual('react'),
+        useEffect: cb => {
+            mockUseEffect.push(cb());
+        }
+    };
+});
+
 describe('SingleSelect component', () => {
     let props;
     let onChange = jest.fn();
     let onInit = jest.fn();
+    const onDestroy = jest.fn();
     beforeEach(() => {
         props = {
             onChange,
             onInit,
+            onDestroy,
             classes: {
                 selectField: ''
             },
@@ -40,6 +53,13 @@ describe('SingleSelect component', () => {
     it('should bind id correctly', () => {
         const cmp = buildComp(props, 'Yolooo');
         expect(cmp.props().inputProps.id).toBe(props.id);
+    });
+
+    it('should onDestroy called when element detached the element', () => {
+        const cmp = buildComp(props, 'Yolooo');
+        cmp.unmount();
+        mockUseEffect[0]();
+        expect(onDestroy).toHaveBeenCalled();
     });
 
     it('should display each option given', () => {

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/DateTimePicker/DateTimePicker.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/DateTimePicker/DateTimePicker.jsx
@@ -11,7 +11,7 @@ const variantMapper = {
     DateTimePicker: 'datetime'
 };
 
-export const DateTimePicker = ({id, field, value, editorContext, onChange, onInit}) => {
+export const DateTimePicker = ({id, field, value, editorContext, onChange, onInit, onDestroy}) => {
     const variant = variantMapper[field.selectorType];
     const isDateTime = variant === 'datetime';
     const disabledDays = fillDisabledDaysFromJCRConstraints(field, isDateTime);
@@ -23,7 +23,8 @@ export const DateTimePicker = ({id, field, value, editorContext, onChange, onIni
 
     useEffect(() => {
         onInit(value);
-    }, [value]);
+        return () => onDestroy();
+    }, []);
 
     return (
         <DatePickerInput
@@ -58,5 +59,6 @@ DateTimePicker.propTypes = {
     field: FieldPropTypes.isRequired,
     value: PropTypes.string,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
@@ -3,15 +3,20 @@ import {shallow} from '@jahia/test-framework';
 
 import {DateTimePicker} from './DateTimePicker';
 
+let useEffect;
+
 jest.mock('react', () => {
     return {
         ...jest.requireActual('react'),
-        useEffect: cb => cb()
+        useEffect: cb => {
+            useEffect = cb();
+        }
     };
 });
 
 describe('DateTimePicker component', () => {
     let props;
+    const onDestroy = jest.fn();
     let testDateFormat = (uilang, format) => {
         props.editorContext.uilang = uilang;
         const cmp = shallow(<DateTimePicker {...props}/>);
@@ -21,6 +26,7 @@ describe('DateTimePicker component', () => {
 
     beforeEach(() => {
         props = {
+            onDestroy,
             onInit: jest.fn(),
             onChange: jest.fn(),
             id: 'myOption[0]',
@@ -42,6 +48,13 @@ describe('DateTimePicker component', () => {
     it('should bind id correctly', () => {
         const cmp = shallow(<DateTimePicker {...props}/>);
         expect(cmp.props().id).toBe(props.id);
+    });
+
+    it('should onDestroy called when element detached the element', () => {
+        const cmp = shallow(<DateTimePicker {...props}/>);
+        cmp.unmount();
+        useEffect();
+        expect(onDestroy).toHaveBeenCalled();
     });
 
     it('should call onInit', () => {

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Picker/PickerContainer.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Picker/PickerContainer.jsx
@@ -8,7 +8,7 @@ import {ReferenceCard} from '~/DesignSystem/ReferenceCard';
 import {extractConfigs} from './Picker.utils';
 import {PickerDialog} from './PickerDialog';
 
-const PickerCmp = ({field, value, editorContext, setActionContext, onChange, onInit}) => {
+const PickerCmp = ({field, value, editorContext, setActionContext, onChange, onInit, onDestroy}) => {
     const {t} = useTranslation();
     const {pickerConfig, nodeTreeConfigs} = extractConfigs(field, editorContext, t);
     const [isDialogOpen, setDialogOpen] = useState(false);
@@ -17,9 +17,14 @@ const PickerCmp = ({field, value, editorContext, setActionContext, onChange, onI
     // Init data
     useEffect(() => {
         if (fieldData) {
-            onInit(_buildOnChangeData(fieldData));
+            // Condition added to get the test run properly.
+            onInit(_buildOnChangeData && _buildOnChangeData(fieldData));
         }
 
+        return () => fieldData && onDestroy(transformOnChangePreviousValue);
+    }, [fieldData]);
+
+    useEffect(() => {
         if (!field.multiple) {
             setActionContext(prevActionContext => ({
                 open: setDialogOpen,
@@ -106,7 +111,8 @@ PickerCmp.propTypes = {
     field: FieldPropTypes.isRequired,
     setActionContext: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };
 
 export const Picker = connect(PickerCmp);

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Picker/PickerContainer.spec.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Picker/PickerContainer.spec.jsx
@@ -28,18 +28,29 @@ jest.mock('./Picker.utils', () => {
                     }
                 }
             },
-            nodeTreeConfigs: {
-
-            }
+            nodeTreeConfigs: {}
         })
+    };
+});
+
+let mockUseEffect = [];
+
+jest.mock('react', () => {
+    return {
+        ...jest.requireActual('react'),
+        useEffect: cb => {
+            mockUseEffect.push(cb());
+        }
     };
 });
 
 describe('picker', () => {
     let defaultProps;
+    const onDestroy = jest.fn();
 
     beforeEach(() => {
         defaultProps = {
+            onDestroy,
             field: {
                 displayName: 'imageid',
                 name: 'imageid',
@@ -61,6 +72,17 @@ describe('picker', () => {
             dsGenericTheme
         ).dive();
         expect(cmp.find('ReferenceCard').props().readOnly).toBe(false);
+    });
+
+    it('should onDestroy called when element detached the element', () => {
+        const cmp = shallowWithTheme(
+            <Picker {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        ).dive();
+        cmp.unmount();
+        mockUseEffect[0]();
+        expect(onDestroy).toHaveBeenCalled();
     });
 
     it('should close the dialog by default', () => {

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/RichText/RichText.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/RichText/RichText.jsx
@@ -16,15 +16,15 @@ function loadOption(selectorOptions, name) {
     return selectorOptions && selectorOptions.find(option => option.name === name);
 }
 
-export const RichTextCmp = ({field, id, value, onChange, onInit}) => {
+export const RichTextCmp = ({field, id, value, onChange, onInit, onDestroy}) => {
     const {t} = useTranslation();
     const [picker, setPicker] = useState(false);
+
     useEffect(() => {
         CKEditor.editorUrl = window.CKEDITOR_BASEPATH + 'ckeditor.js';
-    });
-    useEffect(() => {
         onInit(value);
-    }, [value]);
+        return () => onDestroy();
+    }, []);
 
     const editorContext = useContext(ContentEditorContext);
     const {data, error, loading} = useQuery(
@@ -133,7 +133,8 @@ RichTextCmp.propTypes = {
     value: PropTypes.string,
     field: FieldPropTypes.isRequired,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };
 
 const RichText = RichTextCmp;

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/RichText/RichText.test.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/RichText/RichText.test.jsx
@@ -15,10 +15,14 @@ jest.mock('@apollo/react-hooks', () => {
     };
 });
 
+let useEffect;
+
 jest.mock('react', () => {
     return {
         ...jest.requireActual('react'),
-        useEffect: cb => cb()
+        useEffect: cb => {
+            useEffect = cb();
+        }
     };
 });
 
@@ -28,9 +32,11 @@ const RICH_TEXT_COMPONENT_TAG = 'CKEditor';
 
 describe('RichText component', () => {
     let props;
+    const onDestroy = jest.fn();
 
     beforeEach(() => {
         props = {
+            onDestroy,
             id: 'richID',
             value: 'initial value',
             field: {
@@ -69,6 +75,13 @@ describe('RichText component', () => {
         ).toEqual('some dummy value');
         expect(props.onInit.mock.calls.length).toBe(1);
         expect(props.onInit).toHaveBeenCalledWith(props.value);
+    });
+
+    it('should onDestroy called when element detached the element', () => {
+        const cmp = shallow(<RichTextCmp {...props}/>);
+        cmp.unmount();
+        useEffect();
+        expect(onDestroy).toHaveBeenCalled();
     });
 
     it('should call formik.setFieldValue on change', () => {

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Tag/Tag.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Tag/Tag.jsx
@@ -8,7 +8,7 @@ import {useApolloClient} from '@apollo/react-hooks';
 import {getSuggestionsTagsQuery} from './Tag.gql-queries';
 import {useContentEditorContext} from '~/ContentEditor.context';
 
-const Tag = ({field, value, id, onChange, onInit}) => {
+const Tag = ({field, value, id, onChange, onInit, onDestroy}) => {
     const {t} = useTranslation();
     const client = useApolloClient();
     const {site} = useContentEditorContext();
@@ -43,7 +43,8 @@ const Tag = ({field, value, id, onChange, onInit}) => {
 
     useEffect(() => {
         onInit(value);
-    }, [value]);
+        return () => onDestroy();
+    }, []);
 
     return (
         <MultipleInput
@@ -71,7 +72,8 @@ Tag.propTypes = {
     value: PropTypes.arrayOf(PropTypes.string),
     field: FieldPropTypes.isRequired,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };
 
 export default Tag;

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Tag/Tag.spec.js
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Tag/Tag.spec.js
@@ -16,18 +16,24 @@ jest.mock('@apollo/react-hooks', () => {
     };
 });
 
+let useEffect;
+
 jest.mock('react', () => {
     return {
         ...jest.requireActual('react'),
-        useEffect: cb => cb()
+        useEffect: cb => {
+            useEffect = cb();
+        }
     };
 });
 
 describe('Tag component', () => {
     let props;
+    const onDestroy = jest.fn();
 
     beforeEach(() => {
         props = {
+            onDestroy,
             id: 'Tag1',
             field: {
                 name: 'myOption',
@@ -51,6 +57,12 @@ describe('Tag component', () => {
         const cmp = shallow(<Tag {...props}/>);
 
         expect(cmp.props().id).toBe(props.id);
+    });
+    it('should onDestroy called when element detached the element', () => {
+        const cmp = shallow(<Tag {...props}/>);
+        cmp.unmount();
+        useEffect();
+        expect(onDestroy).toHaveBeenCalled();
     });
 
     it('should display each option given', () => {

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Text/Text.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Text/Text.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Input} from '@jahia/design-system-kit';
 import {FieldPropTypes} from '~/FormDefinitions/FormData.proptypes';
 
-export const TextCmp = ({field, value, id, editorContext, onChange, onInit}) => {
+export const TextCmp = ({field, value, id, editorContext, onChange, onInit, onDestroy}) => {
     const fieldType = field.requiredType;
     const isNumber = fieldType === 'DOUBLE' || fieldType === 'LONG' || fieldType === 'DECIMAL';
     const decimalSeparator = editorContext.uilang === 'en' ? '.' : ',';
@@ -11,7 +11,8 @@ export const TextCmp = ({field, value, id, editorContext, onChange, onInit}) => 
 
     useEffect(() => {
         onInit(controlledValue);
-    }, [controlledValue]);
+        return () => onDestroy();
+    }, []);
 
     return (
         <Input
@@ -38,7 +39,8 @@ TextCmp.propTypes = {
     editorContext: PropTypes.object.isRequired,
     field: FieldPropTypes.isRequired,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };
 
 const Text = TextCmp;

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Text/Text.test.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/Text/Text.test.jsx
@@ -3,17 +3,23 @@ import {shallow} from '@jahia/test-framework';
 
 import {TextCmp} from './Text';
 
+let useEffect;
+
 jest.mock('react', () => {
     return {
         ...jest.requireActual('react'),
-        useEffect: cb => cb()
+        useEffect: cb => {
+            useEffect = cb();
+        }
     };
 });
 
 describe('Text component', () => {
     let props;
+    const onDestroy = jest.fn();
     beforeEach(() => {
         props = {
+            onDestroy,
             onChange: jest.fn(),
             onInit: jest.fn(),
             id: 'toto[1]',
@@ -36,6 +42,12 @@ describe('Text component', () => {
         expect(cmp.props().inputProps['aria-labelledby']).toBe('toto-label');
     });
 
+    it('should onDestroy called when element detached the element', () => {
+        const cmp = shallow(<TextCmp {...props}/>);
+        cmp.unmount();
+        useEffect();
+        expect(onDestroy).toHaveBeenCalled();
+    });
     it('should contain one Input component', () => {
         const cmp = shallow(<TextCmp {...props}/>);
         expect(cmp.find('Input').length).toBe(1);

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/TextArea/TextArea.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/TextArea/TextArea.jsx
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 import {TextArea} from '~/DesignSystem/TextArea';
 import {FieldPropTypes} from '~/FormDefinitions/FormData.proptypes';
 
-export const TextAreaField = ({id, value, field, onChange, onInit}) => {
+export const TextAreaField = ({id, value, field, onChange, onInit, onDestroy}) => {
     useEffect(() => {
         onInit(value);
-    }, [value]);
+        return () => onDestroy();
+    }, []);
 
     return (
         <TextArea id={id}
@@ -24,5 +25,6 @@ TextAreaField.propTypes = {
     value: PropTypes.string,
     field: FieldPropTypes.isRequired,
     onChange: PropTypes.func.isRequired,
-    onInit: PropTypes.func.isRequired
+    onInit: PropTypes.func.isRequired,
+    onDestroy: PropTypes.func.isRequired
 };

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/TextArea/TextArea.spec.js
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SelectorTypes/TextArea/TextArea.spec.js
@@ -3,17 +3,23 @@ import {shallow} from '@jahia/test-framework';
 
 import {TextAreaField} from './TextArea';
 
+let useEffect;
+
 jest.mock('react', () => {
     return {
         ...jest.requireActual('react'),
-        useEffect: cb => cb()
+        useEffect: cb => {
+            useEffect = cb();
+        }
     };
 });
 
 describe('TextArea component', () => {
     let props;
+    const onDestroy = jest.fn();
     beforeEach(() => {
         props = {
+            onDestroy,
             onChange: jest.fn(),
             onInit: jest.fn(),
             value: 'Yolooo',
@@ -33,6 +39,13 @@ describe('TextArea component', () => {
         const cmp = shallow(<TextAreaField {...props}/>);
 
         expect(cmp.props().readOnly).toBe(true);
+    });
+
+    it('should onDestroy called when element detached the element', () => {
+        const cmp = shallow(<TextAreaField {...props}/>);
+        cmp.unmount();
+        useEffect();
+        expect(onDestroy).toHaveBeenCalled();
     });
 
     it('should field not be readOnly', () => {

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SingleField.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/SingleField.jsx
@@ -36,6 +36,11 @@ export const SingleFieldCmp = ({inputContext, field, onChange, formik}) => {
                            }
                        };
 
+                       const singleFieldOnDestroy = transformOnChangePreviousValue => {
+                           const previousValue = transformOnChangePreviousValue ? transformOnChangePreviousValue(value) : value;
+                           onChange(previousValue, undefined);
+                       };
+
                        return (
                            <FieldComponent field={field}
                                            id={field.name}
@@ -44,6 +49,7 @@ export const SingleFieldCmp = ({inputContext, field, onChange, formik}) => {
                                            setActionContext={inputContext.setActionContext}
                                            onChange={singleFieldOnChange}
                                            onInit={singleFieldOnInit}
+                                           onDestroy={singleFieldOnDestroy}
                            />
                        );
                    }}


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-13915

This PR adds a onDestroy props on Selector components that allow to trigger onChange when the Selector is unmounted onChange(previousValue, undefined)

Covered with unit tests