### PR TITLE
BACKLOG-13946 set system name to readonly when node is locked

### DIFF
--- a/src/javascript/FormDefinitions/FormData.adapter.js
+++ b/src/javascript/FormDefinitions/FormData.adapter.js
@@ -37,7 +37,8 @@ export const adaptSystemNameField = (rawData, formData, lang, t, primaryNodeType
                 // System name should be readonly for this specific nodetypes
                 if (Constants.systemName.READONLY_FOR_NODE_TYPES.includes(primaryNodeType.name) ||
                     isContentOrFileNode(formData) ||
-                    (!isCreate && !formData.nodeData.hasWritePermission)) {
+                    (!isCreate && !formData.nodeData.hasWritePermission) ||
+                    formData.nodeData.lockedAndCannotBeEdited) {
                     systemNameField.readOnly = true;
                 }
 

--- a/src/javascript/FormDefinitions/FormData.adapter.spec.js
+++ b/src/javascript/FormDefinitions/FormData.adapter.spec.js
@@ -136,6 +136,18 @@ describe('adaptFormData', () => {
         expect(formData.sections[1].fieldSets[0].fields[0].readOnly).toEqual(true);
     });
 
+    it('should set system name readonly when node is locked and cannot be edited', () => {
+        const nodeType = {
+            name: 'jnt:text',
+            displayName: 'Text'
+        };
+        formData.nodeData.lockedAndCannotBeEdited = true;
+
+        adaptSystemNameField(rawData, formData, null, t, nodeType, false);
+        expect(formData.sections[1].fieldSets[0].fields[0].name).toEqual('ce:systemName');
+        expect(formData.sections[1].fieldSets[0].fields[0].readOnly).toEqual(true);
+    });
+
     it('should set maximum name size validation according to DX prop: maxNameSize', () => {
         const nodeType = {
             name: 'jnt:news',


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-13946

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
