### PR TITLE
BACKLOG-14312: Reversed Colours for "Required" and "Shared by all languages" Badges

### DIFF
--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/ChildrenSection/ChildrenSection.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/ChildrenSection/ChildrenSection.jsx
@@ -70,7 +70,7 @@ export const ChildrenSectionCmp = ({section, classes, formik: {values, handleCha
                            badgeContent={t('content-editor:label.contentEditor.edit.sharedLanguages')}
                            icon={<Public/>}
                            variant="normal"
-                           color="info"
+                           color="primary"
                     />
                 </div>
 

--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/Field.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/Section/FieldSet/Field/Field.jsx
@@ -154,7 +154,7 @@ export const FieldCmp = ({classes, inputContext, idInput, selectorType, field, f
                                                data-sel-content-editor-field-mandatory={Boolean(hasMandatoryError)}
                                                badgeContent={t('content-editor:label.contentEditor.edit.validation.required')}
                                                variant="normal"
-                                               color={hasMandatoryError ? 'warning' : 'primary'}
+                                               color={hasMandatoryError ? 'warning' : 'info'}
                                         />
                                     )}
                                     {showChipField(field.i18n, wipInfo, editorContext.lang) && (
@@ -170,7 +170,7 @@ export const FieldCmp = ({classes, inputContext, idInput, selectorType, field, f
                                            badgeContent={t('content-editor:label.contentEditor.edit.sharedLanguages')}
                                            icon={<Public/>}
                                            variant="normal"
-                                           color="info"
+                                           color="primary"
                                     />}
                                 </>
                             )}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-14312

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Changed Required badge colour to "info" and Shared by all languages badge colour to "primary"
* Affects Field and ChildrenSection components
