### PR TITLE
BACKLOG-14546 : bump app shell to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>app-shell</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <type>json</type>
             <classifier>manifest</classifier>
         </dependency>
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>org.jahia.test</groupId>
             <artifactId>module-test-framework</artifactId>
-            <version>8.0.1.0</version>
+            <version>${parent.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-14546