### PR TITLE
BACKLOG-15112: Change site switcher in picker modal to moonstone dropdown

### DIFF
--- a/src/javascript/DesignSystem/SiteSwitcher/SiteSwitcher.jsx
+++ b/src/javascript/DesignSystem/SiteSwitcher/SiteSwitcher.jsx
@@ -1,74 +1,26 @@
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
-import {Menu, MenuItem, withStyles} from '@material-ui/core';
-import {Button, Typography} from '@jahia/design-system-kit';
-import {ChevronDown} from 'mdi-material-ui';
+import React from 'react';
+import {Dropdown} from '@jahia/moonstone';
+import style from './SiteSwitcher.scss';
 
-const styles = theme => ({
-    siteSwitcher: {
-        margin: theme.spacing.unit * 2
-    },
-    menuDialog: {
-        zIndex: 10012 // IMPORTANT: DO NOT REMOVE: CKEditor image picker is using 10010, CE picker is using 10011, and we need to be on top of this interfaces
-    }
-});
-
-const SiteSwitcherCmp = ({id, siteKey, siteNodes, onSelectSite, classes}) => {
-    const [anchorEl, setAnchorEl] = useState(null);
-
-    const handleClick = event => {
-        setAnchorEl(event.currentTarget);
-    };
-
-    const handleClose = () => {
-        setAnchorEl(null);
-    };
-
-    const siteNode = siteNodes.find(siteNode => siteNode.name === siteKey);
-
+const SiteSwitcher = ({id, siteKey, siteNodes, onSelectSite}) => {
     return (
-        <>
-            <Button aria-owns={anchorEl ? id : null}
-                    size="compact"
-                    color="inverted"
-                    aria-haspopup="true"
-                    data-cm-role={id}
-                    className={classes.siteSwitcher}
-                    onClick={handleClick}
-            >
-                <Typography noWrap variant="zeta" color="inherit">
-                    {siteNode.displayName}
-                </Typography>
-                &nbsp;
-                <ChevronDown fontSize="small" color="inherit"/>
-            </Button>
-            <Menu id={id} anchorEl={anchorEl} open={Boolean(anchorEl)} ModalClasses={{root: classes.menuDialog}} onClose={handleClose}>
-                {siteNodes.map(siteNode => {
-                    return (
-                        <MenuItem
-                            key={siteNode.uuid}
-                            onClick={() => {
-                                onSelectSite(siteNode);
-                                handleClose();
-                            }}
-                        >
-                            {siteNode.displayName}
-                        </MenuItem>
-                    );
-                })}
-            </Menu>
-        </>
+        <Dropdown
+            id={id}
+            size="medium"
+            value={siteKey}
+            className={style.dropdown}
+            label={siteNodes.find(siteNode => siteNode.name === siteKey)?.displayName}
+            data={siteNodes.map(siteNode => ({label: siteNode.displayName, value: siteNode.name}))}
+            onChange={onSelectSite}
+        />
     );
 };
 
-SiteSwitcherCmp.propTypes = {
+SiteSwitcher.propTypes = {
     id: PropTypes.string.isRequired,
-    classes: PropTypes.object.isRequired,
     onSelectSite: PropTypes.func.isRequired,
     siteKey: PropTypes.string.isRequired,
     siteNodes: PropTypes.arrayOf(PropTypes.object).isRequired
 };
-
-const SiteSwitcher = withStyles(styles)(SiteSwitcherCmp);
-SiteSwitcher.displayName = 'SiteSwitcher';
 export default SiteSwitcher;

--- a/src/javascript/DesignSystem/SiteSwitcher/SiteSwitcher.md
+++ b/src/javascript/DesignSystem/SiteSwitcher/SiteSwitcher.md
@@ -5,8 +5,7 @@ This component displays button to allow switching to another site.
 ### Props
 
 -   _id_:           string value for component id
--   _classes_:      object for styling the component
--   _siteKey_:      string of node site key
+-   _site_:      string of node site key
 -   _siteNodes_:    array of objects contains site nodes
 -   _onSelectSite_: function to select site node
 

--- a/src/javascript/DesignSystem/SiteSwitcher/SiteSwitcher.scss
+++ b/src/javascript/DesignSystem/SiteSwitcher/SiteSwitcher.scss
@@ -1,0 +1,5 @@
+.dropdown {
+    margin-bottom: var(--spacing-nano);
+
+    color: var(--color-light);
+}

--- a/src/javascript/DesignSystem/SiteSwitcher/SiteSwitcher.spec.js
+++ b/src/javascript/DesignSystem/SiteSwitcher/SiteSwitcher.spec.js
@@ -5,7 +5,6 @@ import SiteSwitcher from './SiteSwitcher';
 
 describe('SiteSwitcher', () => {
     let defaultProps;
-
     beforeEach(() => {
         defaultProps = {
             id: 'site-switcher',
@@ -33,7 +32,7 @@ describe('SiteSwitcher', () => {
             dsGenericTheme
         );
 
-        expect(cmp.props().siteKey).toBe(defaultProps.siteKey);
+        expect(cmp.props().value).toBe(defaultProps.siteKey);
     });
 
     it('should give the siteNodes props to SiteSwitcher component', () => {
@@ -43,6 +42,14 @@ describe('SiteSwitcher', () => {
             dsGenericTheme
         );
 
-        expect(cmp.props().siteNodes).toBe(defaultProps.siteNodes);
+        expect(cmp.props().data).toEqual([{
+            label: 'Digitall',
+            value: 'digitall'
+        },
+        {
+            label: 'System site',
+            value: 'systemsite'
+        }]
+        );
     });
 });

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 
 import Drawer from '@material-ui/core/Drawer';
 import {NodeTrees, PickerTreeViewMaterial} from '@jahia/react-material';
-import SiteSwitcher from '~/DesignSystem/SiteSwitcher/SiteSwitcher';
 import {Picker} from '@jahia/data-helper';
+import {Dropdown} from '@jahia/moonstone';
+import style from './LeftPanel.scss';
 
 import {withStyles} from '@material-ui/core';
 
@@ -57,16 +58,21 @@ const LeftPanelCmp = ({
             }}
         >
             {showSiteSwitcher &&
-            <SiteSwitcher
-                id="site-switcher"
-                siteKey={site}
-                siteNodes={siteNodes}
-                onSelectSite={siteNode => {
-                    const path = onSelectSite(siteNode);
-                    setOpenPaths([path]);
-                    setSelectedPath(path);
-                }}
-            />}
+                <Dropdown
+                    id="site-switcher"
+                    size="medium"
+                    value={site}
+                    className={style.dropdown}
+                    label={siteNodes.find(siteNode => siteNode.name === site)?.displayName}
+                    data={siteNodes.map(siteNode => ({label: siteNode.displayName, value: siteNode.name}))}
+                    onChange={(e, siteName) => {
+                        const siteNode = siteNodes.find(siteItem => siteItem.name === siteName.value);
+                        const path = onSelectSite(siteNode);
+                        setOpenPaths([path]);
+                        setSelectedPath(path);
+                    }}
+                />
+            }
 
             <NodeTrees path={selectedPath}
                        rootPath="/"

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.jsx
@@ -4,12 +4,11 @@ import PropTypes from 'prop-types';
 import Drawer from '@material-ui/core/Drawer';
 import {NodeTrees, PickerTreeViewMaterial} from '@jahia/react-material';
 import {Picker} from '@jahia/data-helper';
-import {Dropdown} from '@jahia/moonstone';
-import style from './LeftPanel.scss';
 
 import {withStyles} from '@material-ui/core';
 
 import {getDetailedPathArray, getSite} from '../Picker.utils';
+import SiteSwitcher from '~/DesignSystem/SiteSwitcher';
 
 const styles = theme => ({
     drawerPaper: {
@@ -58,22 +57,17 @@ const LeftPanelCmp = ({
             }}
         >
             {showSiteSwitcher &&
-                <Dropdown
-                    id="site-switcher"
-                    size="medium"
-                    value={site}
-                    className={style.dropdown}
-                    label={siteNodes.find(siteNode => siteNode.name === site)?.displayName}
-                    data={siteNodes.map(siteNode => ({label: siteNode.displayName, value: siteNode.name}))}
-                    onChange={(e, siteName) => {
-                        const siteNode = siteNodes.find(siteItem => siteItem.name === siteName.value);
-                        const path = onSelectSite(siteNode);
-                        setOpenPaths([path]);
-                        setSelectedPath(path);
-                    }}
-                />
-            }
-
+            <SiteSwitcher
+                id="site-switcher"
+                siteKey={site}
+                siteNodes={siteNodes}
+                onSelectSite={(e, siteName) => {
+                    const siteNode = siteNodes.find(siteItem => siteItem.name === siteName.value);
+                    const path = onSelectSite(siteNode);
+                    setOpenPaths([path]);
+                    setSelectedPath(path);
+                }}
+            />}
             <NodeTrees path={selectedPath}
                        rootPath="/"
                        siteKey={site}

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.scss
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.scss
@@ -1,0 +1,4 @@
+.dropdown {
+  margin-bottom: var(--spacing-nano);
+  color: var(--color-light);
+}

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.scss
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.scss
@@ -1,4 +1,0 @@
-.dropdown {
-  margin-bottom: var(--spacing-nano);
-  color: var(--color-light);
-}

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.spec.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/LeftPanel.spec.jsx
@@ -25,7 +25,7 @@ describe('PickerDialog - LeftPanel', () => {
         };
     });
 
-    it('should display siteSwitcher when the picker is not of type "site picker"', () => {
+    it('should display the site switcher dropdown when the picker is not of type "site picker"', () => {
         props.field.selectorOptions = [];
         const cmp = shallowWithTheme(
             <LeftPanel {...props}/>,
@@ -33,16 +33,16 @@ describe('PickerDialog - LeftPanel', () => {
             dsGenericTheme
         ).dive();
 
-        expect(cmp.find('SiteSwitcher').exists()).toBe(true);
+        expect(cmp.find('#site-switcher').exists()).toBe(true);
     });
 
-    it('should hide siteSwitcher when the picker is of type "site picker"', () => {
+    it('should hide the site switcher dropdown when the picker is of type "site picker"', () => {
         const cmp = shallowWithTheme(
             <LeftPanel {...props}/>,
             {},
             dsGenericTheme
         ).dive();
 
-        expect(cmp.find('SiteSwitcher').exists()).toBe(false);
+        expect(cmp.find('#site-switcher').exists()).toBe(false);
     });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15112

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Replaces the SiteSwitcher component in LeftPanel with the Moonstone Dropdown component and wires it up accordingly.

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests