### PR TITLE
QA-13585: Missing icons in 3 dots menu in Content Editor

### DIFF
--- a/src/javascript/SelectorTypes/ChoiceList/ChoiceList.actions.js
+++ b/src/javascript/SelectorTypes/ChoiceList/ChoiceList.actions.js
@@ -11,7 +11,9 @@ const registerChoiceListActions = registry => {
         buttonIcon: <DotsVertical/>,
         buttonLabel: 'label.contentEditor.edit.action.fieldMoreOptions',
         menuTarget: 'ChoicelistActions',
-        isShowIcons: true
+        menuItemProps: {
+            isShowIcons: true
+        }
     });
 
     registry.add('action', 'unsetFieldActionChoiceList', unsetFieldAction, {

--- a/src/javascript/SelectorTypes/Picker/actions/index.js
+++ b/src/javascript/SelectorTypes/Picker/actions/index.js
@@ -20,7 +20,9 @@ export const registerPickerActions = registry => {
         buttonIcon: <DotsVertical/>,
         buttonLabel: 'label.contentEditor.edit.action.fieldMoreOptions',
         menuTarget: 'MediaPickerActions',
-        isShowIcons: true,
+        menuItemProps: {
+            isShowIcons: true
+        },
         displayFieldActions: (field, value) => {
             return !field.multiple && value;
         }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13585

## Description

Updated the way the `isShowIcons` prop is passed into the `menuAction` so that the icons appear properly.