### PR TITLE
BACKLOG-15623: Add more actions menu for FilePicker

### DIFF
--- a/src/javascript/SelectorTypes/Picker/Picker.configs.js
+++ b/src/javascript/SelectorTypes/Picker/Picker.configs.js
@@ -154,10 +154,15 @@ export const registerPickerConfig = ceRegistry => {
     ceRegistry.add('pickerConfiguration', 'file', {
         cmp: {
             picker: {
-                ...contentPicker, key: 'FilePicker',
+                ...contentPicker,
+                key: 'FilePicker',
                 pickerInput: {
                     ...contentPicker.pickerInput,
                     emptyLabel: 'content-editor:label.contentEditor.edit.fields.contentPicker.addFile'
+                },
+                PickerDialog: {
+                    ...contentPicker.PickerDialog,
+                    dialogTitle: () => 'content-editor:label.contentEditor.edit.fields.contentPicker.modalFileTitle'
                 }
             },
             treeConfigs: [treeConfigs.files],

--- a/src/javascript/SelectorTypes/Picker/actions/index.js
+++ b/src/javascript/SelectorTypes/Picker/actions/index.js
@@ -30,23 +30,37 @@ export const registerPickerActions = registry => {
         }
     });
 
+    registry.add('action', 'FilePickerMenu', registry.get('action', 'menuAction'), {
+        buttonIcon: <DotsVertical/>,
+        buttonLabel: 'label.contentEditor.edit.action.fieldMoreOptions',
+        menuTarget: 'FilePickerActions',
+        menuItemProps: {
+            isShowIcons: true
+        },
+        displayFieldActions: (field, value) => {
+            return !field.multiple && value;
+        }
+    });
+
     registry.add('action', 'replaceContent', replaceAction, {
         buttonIcon: <Edit/>,
         buttonLabel: 'content-editor:label.contentEditor.edit.fields.actions.replace',
-        targets: ['ContentPickerActions:1', 'MediaPickerActions:1']
+        targets: ['ContentPickerActions:1', 'MediaPickerActions:1', 'FilePickerActions:1']
     });
 
     registry.add('action', 'openInNewTab', openInTabAction, {
         buttonIcon: <Launch/>,
         buttonLabel: 'content-editor:label.contentEditor.edit.fields.actions.newTab',
-        targets: ['ContentPickerActions:2', 'MediaPickerActions:2']
+        targets: ['ContentPickerActions:2', 'MediaPickerActions:2', 'FilePickerActions:2']
     });
 
     registry.add('action', 'unsetFieldActionPicker', unsetFieldAction, {
         buttonIcon: <Cancel/>,
         buttonLabel: 'content-editor:label.contentEditor.edit.fields.actions.clear',
-        targets: ['ContentPickerActions:3', 'MediaPickerActions:3']
+        targets: ['ContentPickerActions:3', 'MediaPickerActions:3', 'FilePickerActions:3']
     });
+
+    console.log('registry', registry);
 
     const fileUploadJContentAction = {
         ...registry.get('action', 'fileUpload'),


### PR DESCRIPTION
## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15623

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Fixes the issue where the 3 dots more actions menu was not appearing for the FilePicker.