### PR TITLE
BACKLOG-15846: Add wrapper div around fieldset label

### DIFF
--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/FieldSet/FieldSet.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/FieldSet/FieldSet.jsx
@@ -10,11 +10,6 @@ import {FieldContainer} from './Field';
 
 let styles = theme => ({
     fieldsetContainer: {},
-    fieldSetTitle: {
-        width: 'auto',
-        textTransform: 'uppercase',
-        padding: `${theme.spacing.unit * 2}px 0`
-    },
     fieldsetTitleContainer: {
         borderTop: `1px solid ${theme.palette.ui.omega}`,
         display: 'flex',
@@ -23,9 +18,18 @@ let styles = theme => ({
         minHeight: '74px',
         margin: `0 ${theme.spacing.unit * 6}px 0 ${theme.spacing.unit * 4}px`
     },
+    labelContainer: {
+        display: 'flex',
+        flexFlow: 'row wrap'
+    },
+    fieldSetTitle: {
+        width: 'auto',
+        textTransform: 'uppercase',
+        padding: `${theme.spacing.unit * 2}px 0`
+    },
     fieldSetDescription: {
-        padding: `0 0 ${theme.spacing.unit * 2}px 53px`,
-        marginTop: '-7px',
+        paddingBottom: `${theme.spacing.unit * 2}px`,
+        marginTop: `${-theme.spacing.unit}px`,
         flexBasis: '100%'
     }
 });
@@ -45,13 +49,15 @@ const FieldSetCmp = ({fieldset, classes, formik: {values, handleChange}}) => {
                         onChange={handleChange}
                 />}
 
-                <Typography component="label" htmlFor={fieldset.name} className={classes.fieldSetTitle} color="alpha" variant="zeta">
-                    {fieldset.displayName}
-                </Typography>
-                {fieldset.description &&
-                <Typography component="label" className={classes.fieldSetDescription} color="beta" variant="omega">
-                    {fieldset.description}
-                </Typography>}
+                <div className={classes.labelContainer}>
+                    <Typography component="label" htmlFor={fieldset.name} className={classes.fieldSetTitle} color="alpha" variant="zeta">
+                        {fieldset.displayName}
+                    </Typography>
+                    {fieldset.description &&
+                    <Typography component="label" className={classes.fieldSetDescription} color="beta" variant="omega">
+                        {fieldset.description}
+                    </Typography>}
+                </div>
             </div>
 
             {activatedFieldSet && fieldset.fields.map(field => {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15846

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fixed a bug where mixin helper text is still indented even without a toggle. Removed hardcoded indent and added a wrapper div around labels so that it flows automatically if toggle is present:

![image](https://user-images.githubusercontent.com/75278792/113902488-f15d1100-979d-11eb-9455-029da96353b9.png)


