### PR TITLE
BACKLOG-15732: Fix wrap on long mixin helper texts

### DIFF
--- a/src/javascript/EditPanel/EditPanelContent/FormBuilder/FieldSet/FieldSet.jsx
+++ b/src/javascript/EditPanel/EditPanelContent/FormBuilder/FieldSet/FieldSet.jsx
@@ -13,14 +13,14 @@ let styles = theme => ({
     fieldsetTitleContainer: {
         borderTop: `1px solid ${theme.palette.ui.omega}`,
         display: 'flex',
-        flexFlow: 'row wrap',
+        flexDirection: 'row',
         alignItems: 'center',
         minHeight: '74px',
         margin: `0 ${theme.spacing.unit * 6}px 0 ${theme.spacing.unit * 4}px`
     },
     labelContainer: {
         display: 'flex',
-        flexFlow: 'row wrap'
+        flexFlow: 'column wrap'
     },
     fieldSetTitle: {
         width: 'auto',
@@ -29,8 +29,7 @@ let styles = theme => ({
     },
     fieldSetDescription: {
         paddingBottom: `${theme.spacing.unit * 2}px`,
-        marginTop: `${-theme.spacing.unit}px`,
-        flexBasis: '100%'
+        marginTop: `${-theme.spacing.unit}px`
     }
 });
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15732

## Description

Fixed layout wrapping issue for helper mixin.

From this: 

![image](https://user-images.githubusercontent.com/75278792/114580976-535dc080-9c4d-11eb-9482-5fba12e80e71.png)

to this:

![image](https://user-images.githubusercontent.com/75278792/114581106-70928f00-9c4d-11eb-9226-344154a34db1.png)


<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
