### PR TITLE
BACKLOG-15803: Bumping the parent version to 8.0.3.0-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.2.0</version>
+        <version>8.0.3.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     <artifactId>content-editor</artifactId>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-15803

## Description

Simple change to bump pom modules version to 8.0.3.0-SNAPSHOT