### PR TITLE
BACKLOG-16064: Add edit permissions for 8.0.2 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.0.3.0-SNAPSHOT</version>
+        <version>8.0.2.0</version>
         <relativePath />
     </parent>
     <artifactId>content-editor</artifactId>

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -4,4 +4,12 @@
         <canSeeAdvancedOptionsTab jcr:primaryType="jnt:permission"/>
         <setContentLimitsOnAreas jcr:primaryType="jnt:permission"/>
     </contentEditor>
+    <jContent jcr:primaryType="jnt:permission">
+        <jContentActions jcr:primaryType="jnt:permission">
+            <pageTreeActions jcr:primaryType="jnt:permission">
+                <editPageAction jcr:primaryType="jnt:permission"/>
+            </pageTreeActions>
+            <editAction jcr:primaryType="jnt:permission"/>
+        </jContentActions>
+    </jContent>
 </permissions>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16064

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Migrate editAction and editPageAction permissions from jcontent to content-editor
- Downgrade parent dependency to 8.0.2.0 (this still requires app-shell 2.3.0, jahia-ui-root 1.3.0 and jcontent 2.4 to work on jahia 8.0.2)

