### PR TITLE
SUP-118: Allow showing of fieldset from templateMixin if part of the …

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
@@ -261,7 +261,7 @@ public class EditorFormServiceImpl implements EditorFormService {
         Map<String, EditorFormSection> formSectionsByName, boolean removed, boolean dynamic, boolean activated,
         Set<String> processedProperties, boolean isForExtendMixin) throws RepositoryException {
 
-        final boolean displayFieldSet = !fieldSetNodeType.isNodeType("jmix:templateMixin");
+        final boolean displayFieldSet = !fieldSetNodeType.isNodeType("jmix:templateMixin") || primaryNodeType.isNodeType("jmix:templateMixin");
         EditorFormFieldSet nodeTypeFieldSet = generateEditorFormFieldSet(processedProperties, fieldSetNodeType, existingNode, parentNode,
             locale, uiLocale, removed, dynamic, activated, displayFieldSet, isForExtendMixin);
         nodeTypeFieldSet = mergeWithStaticFormFieldSets(fieldSetNodeType.getName(), nodeTypeFieldSet);

--- a/src/test/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImplTest.java
+++ b/src/test/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImplTest.java
@@ -543,6 +543,24 @@ public class EditorFormServiceImplTest extends AbstractJUnitTest {
             + "section");
     }
 
+    @Test
+    public void testPrimaryNodeTypeExtendsTemplateMixin() throws Exception {
+        JCRNodeWrapper simpleContent = session.getNode(testSite.getJCRLocalPath()).addNode("externalLinkIssueExample", "jnt:externalLinkIssueExample");
+        session.save();
+        // edit
+        EditorForm form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, simpleContent.getPath());
+        EditorFormFieldSet fs = getFieldSet(form, "content", "jmix:externalLink");
+        Assert.isTrue(fs.getDisplayed(), "FieldSet should be displayed");
+        Assert.isTrue(fs.getActivated(), "FieldSet should be activated");
+        Assert.isTrue(!fs.getDynamic(), "FieldSet should not be dynamic");
+        Assert.isTrue(hasField(form, "content", "jnt:externalLinkIssueExample", "text"), "could not find text in content "
+            + "section");
+        Assert.isTrue(hasField(form, "content", "jmix:externalLink", "j:linkTitle"), "could not find text in content "
+            + "section");
+        Assert.isTrue(hasField(form, "content", "jmix:externalLink", "j:url"), "could not find text in content "
+            + "section");
+    }
+
     private URL getResource(String s) {
         return getClass().getClassLoader().getResource(s);
     }

--- a/src/test/resources/META-INF/definitions.cnd
+++ b/src/test/resources/META-INF/definitions.cnd
@@ -125,3 +125,6 @@ extends=jnt:text
 - subTitle (string) mandatory internationalized
 
 [jmix:hasPreview] mixin
+
+[jnt:externalLinkIssueExample] > jnt:content, jmix:basicContent, jmix:externalLink
+ - text (string, richtext) internationalized


### PR DESCRIPTION
…primary node type

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/SUP-118

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
