### PR TITLE
QA-13804: Make `pcNavigateTo` action also handle node path changes 

### DIFF
--- a/src/javascript/Edit/Edit.jsx
+++ b/src/javascript/Edit/Edit.jsx
@@ -48,8 +48,8 @@ export const EditCmp = ({
             editCallback: (node, mutateNode) => {
                 const overridedStoredLocation = contentEditorConfigContext.envProps.handleRename && contentEditorConfigContext.envProps.handleRename(node, mutateNode);
                 // Trigger Page Composer to reload iframe if system name was renamed
-                if (mutateNode.rename) {
-                    dispatch(pcNavigateTo({oldPath: node.path, newPath: mutateNode.rename}));
+                if (node.path !== mutateNode.node.path) {
+                    dispatch(pcNavigateTo({oldPath: node.path, newPath: mutateNode.node.path}));
                     invalidateRefetch(`${getPreviewPath(nodeData)}_${lang}`);
                 }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13804

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Dispatch `pcNavigateTo` whenever path changes not just on local renames
