### PR TITLE
QA-13833: Add unmark WIP option for previous multi-language WIP

### DIFF
--- a/src/javascript/EditPanel/WorkInProgress/OpenWorkInProgressModal.action.jsx
+++ b/src/javascript/EditPanel/WorkInProgress/OpenWorkInProgressModal.action.jsx
@@ -13,7 +13,9 @@ export const OpenWorkInProgressModal = ({siteInfo, nodeData, formik, language, r
 
     const wipInfo = formik.values[Constants.wip.fieldName];
     const singleLanguage = siteInfo.languages.length === 1;
-    const isMarkAsWIP = singleLanguage && wipInfo.status === Constants.wip.status.ALL_CONTENT;
+    const isMarkAsWIP = singleLanguage &&
+        (wipInfo.status === Constants.wip.status.ALL_CONTENT ||
+            wipInfo.status === Constants.wip.status.LANGUAGES);
     const buttonLabelKind = isMarkAsWIP ? 'unmark' : 'mark';
     const buttonLabel = `content-editor:label.contentEditor.edit.action.workInProgress.label.${buttonLabelKind}`;
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13833

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

See ticket for scenario.

Modify logic to show unmark WIP option by checking for both single language and multilanguage WIP nodes, as long as it's single language.
