### PR TITLE
BACKLOG-13406: fixed form  on save

### DIFF
--- a/src/javascript/Create/CreateForm/create.action.js
+++ b/src/javascript/Create/CreateForm/create.action.js
@@ -25,7 +25,7 @@ const Create = ({mode, values, errors, dirty, render: Render, loading: Loading, 
                         return formik
                             .submitForm()
                             .then(() => {
-                                formik.resetForm(values);
+                                formik.resetForm({values});
                             });
                     }
                 }}/>

--- a/src/javascript/Edit/save/save.action.jsx
+++ b/src/javascript/Edit/save/save.action.jsx
@@ -4,12 +4,10 @@ import React, {useContext} from 'react';
 import {ComponentRendererContext} from '@jahia/ui-extender';
 import * as PropTypes from 'prop-types';
 import {usePublicationInfoContext} from '~/PublicationInfo/PublicationInfo.context';
-import {useContentEditorContext} from '~/ContentEditor.context';
 
 const Save = ({values, errors, dirty, mode, render: Render, loading: Loading, ...otherProps}) => {
     const componentRenderer = useContext(ComponentRendererContext);
     const {publicationInfoPolling} = usePublicationInfoContext();
-    const {refetchFormData} = useContentEditorContext();
 
     if (Loading) {
         return <Loading {...otherProps}/>;
@@ -27,9 +25,7 @@ const Save = ({values, errors, dirty, mode, render: Render, loading: Loading, ..
                     return formik
                         .submitForm()
                         .then(() => {
-                            // TODO BACKLOG-13406 avoid refretch if possible
-                            refetchFormData();
-                            formik.resetForm(values);
+                            formik.resetForm({values});
                         });
                 }
             }}

--- a/src/javascript/EditPanel/EditPanel.jsx
+++ b/src/javascript/EditPanel/EditPanel.jsx
@@ -28,7 +28,9 @@ const EditPanelCmp = ({formik, title, notificationContext, client}) => {
         if (envProps.initCallback) {
             envProps.initCallback(formik);
         }
+    }, []);
 
+    useEffect(() => {
         const handleBeforeUnloadEvent = ev => {
             ev.preventDefault();
             ev.returnValue = '';


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-13406

## Description

- resetForm(value) is completely useless, it needs an object with "values" inside.
- refetchFormData() is unneeded
- major issue in EditPanel, initCallback() was called on every change of "dirty" flag, breaking the form on every save ( in page-composer)