### PR TITLE
QA-14023 Remove quote char

### DIFF
--- a/src/javascript/SelectorTypes/SystemName/SystemName.utils.jsx
+++ b/src/javascript/SelectorTypes/SystemName/SystemName.utils.jsx
@@ -43,7 +43,7 @@ const mapSpecialCharacter = {
 };
 
 export const replaceSpecialCharacters = systemName => {
-    const newSystemName = systemName?.replace(/[^A-Z0-9-_,()'!]/ig, character => {
+    const newSystemName = systemName?.replace(/[^A-Z0-9-_,()!]/ig, character => {
         return mapSpecialCharacter[character] || '-';
     });
 


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-14023

## Description

When you add a page, if you set the title "C'est chouette", the generated system name is "c'est-chouette". 

We should avoid quotes in system name; it's a source of troubles.

On Jahia 7, the quote was removed.


