### PR TITLE
Use nsauthoringApi in current window

### DIFF
--- a/src/javascript/Api/ContentEditor.api.jsx
+++ b/src/javascript/Api/ContentEditor.api.jsx
@@ -39,8 +39,8 @@ let styles = () => {
 
 function triggerEvents(nodeUuid, operator) {
 // Refresh contentEditorEventHandlers
-    if (window.top.contentEditorEventHandlers && Object.keys(window.top.contentEditorEventHandlers).length > 0) {
-        Object.values(window.top.contentEditorEventHandlers)
+    if (window.parent.contentEditorEventHandlers && Object.keys(window.parent.contentEditorEventHandlers).length > 0) {
+        Object.values(window.parent.contentEditorEventHandlers)
             .forEach(handler =>
                 handler({nodeUuid: nodeUuid, operator: operator})
             );
@@ -71,8 +71,8 @@ const ContentEditorApiCmp = ({classes, client}) => {
      */
     window.CE_API.edit = (uuid, site, lang, uilang, isWindow, editCallback) => {
         // Sync GWT language
-        if (window.top.authoringApi.switchLanguage) {
-            window.top.authoringApi.switchLanguage(lang);
+        if (window.authoringApi.switchLanguage) {
+            window.authoringApi.switchLanguage(lang);
         }
 
         setEditorConfig({
@@ -105,8 +105,8 @@ const ContentEditorApiCmp = ({classes, client}) => {
     // eslint-disable-next-line
     window.CE_API.create = (uuid, path, site, lang, uilang, nodeTypes, excludedNodeTypes, includeSubTypes, name) => {
         // Sync GWT language
-        if (window.top.authoringApi.switchLanguage) {
-            window.top.authoringApi.switchLanguage(lang);
+        if (window.authoringApi.switchLanguage) {
+            window.authoringApi.switchLanguage(lang);
         }
 
         getCreatableNodetypes(
@@ -152,8 +152,8 @@ const ContentEditorApiCmp = ({classes, client}) => {
 
     const closeAll = () => {
         // Restore GWT language
-        if (window.top.authoringApi.switchLanguage) {
-            window.top.authoringApi.switchLanguage(editorConfig.initLang);
+        if (window.authoringApi.switchLanguage) {
+            window.authoringApi.switchLanguage(editorConfig.initLang);
         }
 
         setEditorConfig(false);
@@ -167,8 +167,8 @@ const ContentEditorApiCmp = ({classes, client}) => {
         },
         back: (nodeUuid, operation, newContentUuid, byPassEventTriggers) => {
             // Refresh GWT content
-            if (window.top.authoringApi.refreshContent) {
-                window.top.authoringApi.refreshContent();
+            if (window.authoringApi.refreshContent) {
+                window.authoringApi.refreshContent();
             }
 
             if (!byPassEventTriggers) {
@@ -181,8 +181,8 @@ const ContentEditorApiCmp = ({classes, client}) => {
         disabledBack: () => false,
         createCallback: (createdNodeUuid, lang) => {
             // Refresh GWT content
-            if (window.top.authoringApi.refreshContent) {
-                window.top.authoringApi.refreshContent();
+            if (window.authoringApi.refreshContent) {
+                window.authoringApi.refreshContent();
             }
 
             triggerEvents(createdNodeUuid, Constants.operators.create);
@@ -203,8 +203,8 @@ const ContentEditorApiCmp = ({classes, client}) => {
         },
         editCallback: nodeUuid => {
             // Refresh GWT content
-            if (window.top.authoringApi.refreshContent) {
-                window.top.authoringApi.refreshContent();
+            if (window.authoringApi.refreshContent) {
+                window.authoringApi.refreshContent();
             }
 
             if (editorConfig && editorConfig.editCallback) {

--- a/src/javascript/Api/ContentEditor.api.jsx
+++ b/src/javascript/Api/ContentEditor.api.jsx
@@ -39,8 +39,8 @@ let styles = () => {
 
 function triggerEvents(nodeUuid, operator) {
 // Refresh contentEditorEventHandlers
-    if (window.parent.contentEditorEventHandlers && Object.keys(window.parent.contentEditorEventHandlers).length > 0) {
-        Object.values(window.parent.contentEditorEventHandlers)
+    if (window.top.contentEditorEventHandlers && Object.keys(window.top.contentEditorEventHandlers).length > 0) {
+        Object.values(window.top.contentEditorEventHandlers)
             .forEach(handler =>
                 handler({nodeUuid: nodeUuid, operator: operator})
             );

--- a/src/javascript/ContentEditor.redux.jsx
+++ b/src/javascript/ContentEditor.redux.jsx
@@ -25,8 +25,8 @@ const ContentEditorReduxCmp = ({client, mode, uuid, lang, uilang, site, contentT
     const dispatch = useDispatch();
     const {t} = useTranslation('content-editor');
     // Sync GWT language
-    if (window.top.authoringApi.switchLanguage) {
-        window.top.authoringApi.switchLanguage(lang);
+    if (window.authoringApi.switchLanguage) {
+        window.authoringApi.switchLanguage(lang);
     }
 
     const handleRename = (node, mutateNode) => {

--- a/src/javascript/ContentEditorHistory/ContentEditorHistory.jsx
+++ b/src/javascript/ContentEditorHistory/ContentEditorHistory.jsx
@@ -30,8 +30,8 @@ export const useContentEditorHistory = () => {
 
     const exit = overridedStoredLocation => {
         // Restore GWT language
-        if (window.top.authoringApi.switchLanguage) {
-            window.top.authoringApi.switchLanguage(storedLocation.language);
+        if (window.authoringApi.switchLanguage) {
+            window.authoringApi.switchLanguage(storedLocation.language);
         }
 
         // In order use:

--- a/src/javascript/Edit/startWorkflow/startWorkflow.action.spec.js
+++ b/src/javascript/Edit/startWorkflow/startWorkflow.action.spec.js
@@ -10,7 +10,7 @@ describe('startWorkflow action', () => {
     beforeEach(() => {
         StartWorkflowAction = startWorkflowAction.component;
 
-        window.parent.authoringApi = {
+        window.authoringApi = {
             openPublicationWorkflow: jest.fn()
         };
 
@@ -81,7 +81,7 @@ describe('startWorkflow action', () => {
             enabled: true
         });
 
-        expect(window.parent.authoringApi.openPublicationWorkflow).toHaveBeenCalled();
+        expect(window.authoringApi.openPublicationWorkflow).toHaveBeenCalled();
     });
 
     it('should not display startWorkflowAction when user doesn\'t have start workflow right', () => {

--- a/src/javascript/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
+++ b/src/javascript/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
@@ -30,8 +30,8 @@ const EditPanelLanguageSwitcher = ({siteInfo, formik}) => {
         }
 
         // Switch edit mode linker language
-        if (window.top.authoringApi.switchLanguage) {
-            window.top.authoringApi.switchLanguage(language);
+        if (window.authoringApi.switchLanguage) {
+            window.authoringApi.switchLanguage(language);
         }
     };
 

--- a/src/javascript/Lock/LockManager.js
+++ b/src/javascript/Lock/LockManager.js
@@ -44,8 +44,8 @@ export const LockManager = ({uuid}) => {
                     client.reFetchObservableQueries();
 
                     // Manual refresh GWT content to avoid page composer left tree node displayed as locked
-                    if (window.top.authoringApi.refreshContent) {
-                        window.top.authoringApi.refreshContent();
+                    if (window.authoringApi.refreshContent) {
+                        window.authoringApi.refreshContent();
                     }
                 })
                 .catch(err => console.error(err));


### PR DESCRIPTION
nsauthoringApi is always in current window, and these indirection prevent content-editor to be used in any frame (like in cypress)