### PR TITLE
QA-14183: Do not throw error if RichText can not read CKeditor config

### DIFF
--- a/src/javascript/EditPanel/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.jsx
+++ b/src/javascript/EditPanel/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.jsx
@@ -19,7 +19,7 @@ export const AdvancedOptionsNavigation = ({formik, activeOption, setActiveOption
 
     if (error) {
         const message = t(
-            'content-media-manager:label.contentManager.error.queryingContent',
+            'content-editor:label.contentEditor.error.queryingContent',
             {details: error.message ? error.message : ''}
         );
         return <>{message}</>;

--- a/src/javascript/EditPanel/EditPanelContent/Preview/Preview.fetcher.js
+++ b/src/javascript/EditPanel/EditPanelContent/Preview/Preview.fetcher.js
@@ -30,7 +30,7 @@ export const PreviewFetcher = React.memo(({onContentNotFound}) => {
 
     if (error) {
         const message = t(
-            'content-media-manager:label.contentManager.error.queryingContent',
+            'content-editor:label.contentEditor.error.queryingContent',
             {details: error.message ? error.message : ''}
         );
         return <>{message}</>;

--- a/src/javascript/FormDefinitions/FormDefinitions.js
+++ b/src/javascript/FormDefinitions/FormDefinitions.js
@@ -10,7 +10,7 @@ export const useFormDefinition = (query, queryParams, adapter, t, contentEditorC
         return {
             loading,
             error,
-            errorMessage: error && t('content-media-manager:label.contentManager.error.queryingContent', {details: (error.message ? error.message : '')})
+            errorMessage: error && t('content-editor:label.contentEditor.error.queryingContent', {details: (error.message ? error.message : '')})
         };
     }
 

--- a/src/javascript/PublicationInfo/PublicationInfo.jsx
+++ b/src/javascript/PublicationInfo/PublicationInfo.jsx
@@ -31,7 +31,7 @@ export const usePublicationInfo = (queryParams, t) => {
             publicationInfoPolling: polling,
             publicationInfoLoading: loading,
             publicationInfoError: error,
-            publicationInfoErrorMessage: error && t('content-media-manager:label.contentManager.error.queryingContent', {details: (error.message ? error.message : '')})
+            publicationInfoErrorMessage: error && t('content-editor:label.contentEditor.error.queryingContent', {details: (error.message ? error.message : '')})
         };
     }
 

--- a/src/javascript/SelectorTypes/Category/Category.jsx
+++ b/src/javascript/SelectorTypes/Category/Category.jsx
@@ -24,8 +24,8 @@ const Category = ({field, value, id, editorContext, onChange}) => {
 
     if (error) {
         const message = t(
-            'content-media-manager:label.contentManager.error.queryingContent',
-            {details: error.message ? error.message : ''}
+            'content-editor:label.contentEditor.error.queryingContent',
+            {details: `/sites/systemsite/categories in ${editorContext.lang}`}
         );
         return <>{message}</>;
     }

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/Views/Thumbnail/Thumbnail.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/Views/Thumbnail/Thumbnail.jsx
@@ -52,7 +52,7 @@ const ThumbnailCmp = ({
 
     if (error) {
         const message = t(
-            'content-media-manager:label.contentManager.error.queryingContent',
+            'content-editor:label.contentEditor.error.queryingContent',
             {details: error.message ? error.message : ''}
         );
         console.warn(message);

--- a/src/javascript/SelectorTypes/RichText/RichText.jsx
+++ b/src/javascript/SelectorTypes/RichText/RichText.jsx
@@ -35,7 +35,11 @@ export const RichTextCmp = ({field, id, value, onChange}) => {
     );
 
     if (error) {
-        throw error;
+        const message = t(
+            'content-editor:label.contentEditor.error.queryingContent',
+            {details: editorContext.path}
+        );
+        return <>{message}</>;
     }
 
     if (loading || !data || !data.forms) {


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14183

## Description

Display error message instead of throwing error. 
Fix label for errors about querying content

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
