### PR TITLE
QA-14183: port from 3.3.2 to 3.4.0

### DIFF
--- a/src/javascript/Edit/Edit.jsx
+++ b/src/javascript/Edit/Edit.jsx
@@ -3,7 +3,11 @@ import {withNotifications} from '@jahia/react-material';
 import {Formik} from 'formik';
 import EditPanel from '~/EditPanel';
 import * as PropTypes from 'prop-types';
-import {useContentEditorContext, withContentEditorDataContextProvider} from '~/ContentEditor.context';
+import {
+    useContentEditorContext,
+    withContentEditorDataContextProvider,
+    useContentEditorConfigContext
+} from '~/ContentEditor.context';
 import {validate} from '~/Validation/validation';
 import {saveNode} from './save/save.request';
 import {PublicationInfoContextProvider} from '~/PublicationInfo/PublicationInfo.context';
@@ -12,7 +16,6 @@ import {useTranslation} from 'react-i18next';
 import {FormQuery} from './EditForm.gql-queries';
 import {withApollo} from 'react-apollo';
 import {compose} from '~/utils';
-import {useContentEditorConfigContext} from '~/ContentEditor.context';
 import {useContentEditorSectionContext} from '~/ContentEditorSection/ContentEditorSection.context';
 import {useDispatch} from 'react-redux';
 import {invalidateRefetch} from '~/EditPanel/EditPanel.refetches';
@@ -49,7 +52,10 @@ export const EditCmp = ({
                 const overridedStoredLocation = contentEditorConfigContext.envProps.handleRename && contentEditorConfigContext.envProps.handleRename(node, mutateNode);
                 // Trigger Page Composer to reload iframe if system name was renamed
                 if (node.path !== mutateNode.node.path) {
-                    dispatch(pcNavigateTo({oldPath: node.path, newPath: mutateNode.node.path}));
+                    if (contentEditorConfigContext.env === 'standalone') {
+                        dispatch(pcNavigateTo({oldPath: node.path, newPath: mutateNode.node.path}));
+                    }
+
                     invalidateRefetch(`${getPreviewPath(nodeData)}_${lang}`);
                 }
 
@@ -65,7 +71,9 @@ export const EditCmp = ({
                 // Hard reFetch to be able to enable publication menu from jContent menu displayed in header
                 // Note that node cache is flushed in save.request.js, we should probably replace this operation with
                 // Something less invasive as this one reloads ALL queries.
-                client.reFetchObservableQueries();
+                if (node.path === mutateNode.node.path) {
+                    client.reFetchObservableQueries();
+                }
             }
         });
     };
@@ -74,7 +82,6 @@ export const EditCmp = ({
         <>
             <PublicationInfoContextProvider uuid={nodeData.uuid} lang={lang}>
                 <Formik
-                    enableReinitialize
                     validateOnMount
                     initialValues={initialValues}
                     validate={validate(sections)}

--- a/src/javascript/EditPanel/header/ContentBreadcrumb/ContentPath/ContentPath.container.jsx
+++ b/src/javascript/EditPanel/header/ContentBreadcrumb/ContentPath/ContentPath.container.jsx
@@ -97,12 +97,12 @@ const ContentPathContainer = ({path, ...context}) => {
         }
     };
 
-    if (error) {
-        console.log(error);
-    }
-
     const node = data?.jcr?.node;
     const items = useMemo(() => getItems(mode, node), [node]);
+
+    if (error) {
+        return <>{error.message}</>;
+    }
 
     return (
         <>

--- a/src/javascript/EditPanel/header/ContentBreadcrumb/ContentPath/ContentPath.container.spec.jsx
+++ b/src/javascript/EditPanel/header/ContentBreadcrumb/ContentPath/ContentPath.container.spec.jsx
@@ -183,14 +183,35 @@ describe('ContentPathContainer', () => {
             }
         }));
 
-        shallow(<ContentPathContainer {...defaultProps}/>);
-        expect(console.log).toHaveBeenCalledWith({
-            message: 'The error is here!',
-            code: '25'
-        });
+        const wrapper = shallow(<ContentPathContainer {...defaultProps}/>);
+        expect(wrapper.text()).toContain('The error is here!');
     });
 
     it('handle redirects on item click', () => {
+        const ancestors = [{
+            uuid: 'x',
+            path: '/x',
+            isVisibleInContentTree: true
+        }, {
+            uuid: 'y',
+            path: '/x/y',
+            isVisibleInContentTree: true
+        }, {
+            uuid: 'z',
+            path: '/x/y/z',
+            isVisibleInContentTree: true
+        }];
+
+        useQuery.mockImplementation(() => ({
+            data: {
+                jcr: {
+                    node: {
+                        isVisibleInContentTree: true,
+                        ancestors: ancestors
+                    }
+                }
+            }
+        }));
         const wrapper = shallow(<ContentPathContainer {...defaultProps}/>);
         wrapper.find('ContentPath').simulate('itemClick', '/x/y/z');
 

--- a/src/javascript/FormDefinitions/FormDefinitions.js
+++ b/src/javascript/FormDefinitions/FormDefinitions.js
@@ -1,10 +1,17 @@
 import {useQuery} from '@apollo/react-hooks';
+import {useMemo} from 'react';
 
 export const useFormDefinition = (query, queryParams, adapter, t, contentEditorConfigContext) => {
     const {loading, error, data, refetch} = useQuery(query, {
         variables: queryParams,
         fetchPolicy: 'network-only'
     });
+
+    const dataCached = useMemo(() => {
+        if (!error && !loading && data.jcr) {
+            return adapter(data, queryParams.uilang, t, contentEditorConfigContext);
+        }
+    }, [data, queryParams.uilang, t, contentEditorConfigContext, error, loading]);
 
     if (error || loading || !data.jcr) {
         return {
@@ -14,5 +21,5 @@ export const useFormDefinition = (query, queryParams, adapter, t, contentEditorC
         };
     }
 
-    return {data: adapter(data, queryParams.uilang, t, contentEditorConfigContext), refetch};
+    return {data: dataCached, refetch};
 };

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
@@ -71,6 +71,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
@@ -172,9 +173,14 @@ public class GqlEditorForms {
     @GraphQLName("ckeditorConfigPath")
     @GraphQLDescription("Retrieve the custom configuration path for CKEditor")
     public String ckeditorConfigPath(@GraphQLName("nodePath") @GraphQLDescription("node path") String nodePath) throws RepositoryException {
+        String configPath;
         // Retrieve custom configuration from template set module
-        String templatesSet = getSession().getNode(nodePath).getResolveSite().getPropertyAsString("j:templatesSet");
-        String configPath = getConfigPath(templatesSet, "/javascript/ckeditor_config.js");
+        try {
+            String templatesSet = getSession().getNode(nodePath).getResolveSite().getPropertyAsString("j:templatesSet");
+            configPath = getConfigPath(templatesSet, "/javascript/ckeditor_config.js");
+        } catch (PathNotFoundException e) {
+            configPath = "";
+        }
 
         // Otherwise, retrieve custom configuration from global configuration
         if (configPath.isEmpty()) {
@@ -189,12 +195,15 @@ public class GqlEditorForms {
     @GraphQLDescription("Retrieve the toolbar type for CKEditor")
     public String ckeditorToolbar(@GraphQLName("nodePath") @GraphQLDescription("node path") String nodePath) throws RepositoryException {
         String toolbar = "Light";
-
-        JCRNodeWrapper node = getSession().getNode(nodePath);
-        if (node.hasPermission("view-full-wysiwyg-editor")) {
-            toolbar = "Full";
-        } else if (node.hasPermission("view-basic-wysiwyg-editor")) {
-            toolbar = "Basic";
+        try {
+            JCRNodeWrapper node = getSession().getNode(nodePath);
+            if (node.hasPermission("view-full-wysiwyg-editor")) {
+                toolbar = "Full";
+            } else if (node.hasPermission("view-basic-wysiwyg-editor")) {
+                toolbar = "Basic";
+            }
+        } catch (PathNotFoundException e) {
+            logger.debug("Path does not exist {}", nodePath);
         }
 
         return toolbar;


### PR DESCRIPTION
…n redux mode  (#1040)

* QA-14183: Handle errors differently in ContentPath, avoid doing refetchObservables in Edit.jsx, handle PathNotFpundException exceptions on GraphQL side. Return default configuration if needed for CKeditor

* QA-14183: Avoid calling dispatch to pcNavigateTo if not calling from PageComposer

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14183

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
