### PR TITLE
BACKLOG-16953: Use stable callback

### DIFF
--- a/src/javascript/DesignSystem/ContentTable/ContentRow.jsx
+++ b/src/javascript/DesignSystem/ContentTable/ContentRow.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import PropTypes from 'prop-types';
 import {withStyles} from '@material-ui/core/styles';
 import TableCell from '@material-ui/core/TableCell';
@@ -38,8 +38,9 @@ const styles = theme => ({
 const ContentRowCmp = ({row, selected, columns, onClick, classes}) => {
     const [rowData, setRowData] = useState(row);
 
-    const updateRowProperties = rowPropertiesToUpdate =>
-        setRowData({...rowData, ...rowPropertiesToUpdate});
+    const updateRowProperties = useCallback(rowPropertiesToUpdate => {
+        setRowData(previousData => ({...previousData, ...rowPropertiesToUpdate}));
+    }, [setRowData]);
 
     // Sometimes some data for the row need to be loaded after the row is displayed
     const LazyRowLoader = row.lazyRowLoader;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16953

## Description

Avoid endless render loop in SubContentCountLazyLoader because of redefined "updateRow" callback
