### PR TITLE
QA-13660: refresh only when closing edit/create

### DIFF
--- a/src/javascript/Api/ContentEditor.api.jsx
+++ b/src/javascript/Api/ContentEditor.api.jsx
@@ -168,11 +168,6 @@ const ContentEditorApiCmp = ({classes, client}) => {
             formikRef.current = formik;
         },
         back: (nodeUuid, operation, newContentUuid, byPassEventTriggers) => {
-            // Refresh GWT content
-            if (window.authoringApi.refreshContent) {
-                window.authoringApi.refreshContent();
-            }
-
             if (!byPassEventTriggers) {
                 triggerEvents(newContentUuid || nodeUuid, operation);
             }
@@ -182,11 +177,6 @@ const ContentEditorApiCmp = ({classes, client}) => {
         },
         disabledBack: () => false,
         createCallback: (createdNodeUuid, lang) => {
-            // Refresh GWT content
-            if (window.authoringApi.refreshContent) {
-                window.authoringApi.refreshContent();
-            }
-
             triggerEvents(createdNodeUuid, Constants.operators.create);
 
             if (editorConfig && editorConfig.createCallback) {
@@ -204,11 +194,6 @@ const ContentEditorApiCmp = ({classes, client}) => {
             }
         },
         editCallback: nodeUuid => {
-            // Refresh GWT content
-            if (window.authoringApi.refreshContent) {
-                window.authoringApi.refreshContent();
-            }
-
             if (editorConfig && editorConfig.editCallback) {
                 editorConfig.editCallback(nodeUuid);
             }

--- a/src/javascript/Api/ContentEditor.api.jsx
+++ b/src/javascript/Api/ContentEditor.api.jsx
@@ -184,12 +184,14 @@ const ContentEditorApiCmp = ({classes, client}) => {
             }
 
             // Redirect to CE edit mode, for the created node
+            envProps.isNeedRefresh = false;
             if (editorConfig) {
                 setEditorConfig({
                     ...editorConfig,
                     uuid: createdNodeUuid,
                     lang: lang ? lang : editorConfig.lang,
-                    mode: Constants.routes.baseEditRoute
+                    mode: Constants.routes.baseEditRoute,
+                    fromCreate: true
                 });
             }
         },
@@ -200,6 +202,12 @@ const ContentEditorApiCmp = ({classes, client}) => {
 
             // Refresh contentEditorEventHandlers
             triggerEvents(nodeUuid, Constants.operators.update);
+        },
+        isNeedRefresh: Boolean(editorConfig.fromCreate),
+        onClosedCallback: () => {
+            if (window.authoringApi.refreshContent && envProps.isNeedRefresh) {
+                window.authoringApi.refreshContent();
+            }
         },
         setLanguage: lang => {
             // Update the lang of current opened CE

--- a/src/javascript/Create/Create.jsx
+++ b/src/javascript/Create/Create.jsx
@@ -31,13 +31,15 @@ const CreateCmp = ({
 
     useEffect(() => {
         return () => {
-            if (window.authoringApi.refreshContent) {
-                window.authoringApi.refreshContent();
+            if (contentEditorConfigContext.envProps.onClosedCallback) {
+                contentEditorConfigContext.envProps.onClosedCallback();
             }
         };
-    }, []);
+    }, [contentEditorConfigContext.envProps]);
 
     const handleSubmit = (values, actions) => {
+        contentEditorConfigContext.envProps.isNeedRefresh = true;
+
         createNode({
             client,
             t,

--- a/src/javascript/Create/Create.jsx
+++ b/src/javascript/Create/Create.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {withNotifications} from '@jahia/react-material';
 import {Formik} from 'formik';
 import EditPanel from '~/EditPanel';
@@ -14,20 +14,28 @@ import {useContentEditorSectionContext} from '~/ContentEditorSection/ContentEdit
 import {validate} from '~/Validation/validation';
 import {createNode} from './CreateForm/create.request';
 import {FormQuery} from './CreateForm/createForm.gql-queries';
-import {withApollo} from 'react-apollo';
 import {compose} from '~/utils';
 import envCreateCallbacks from './Create.env';
 import {adaptCreateFormData} from './Create.adapter';
 import {Constants} from '~/ContentEditor.constants';
+import {useApolloClient} from '@apollo/react-hooks';
 
 const CreateCmp = ({
-    client,
     notificationContext
 }) => {
+    const client = useApolloClient();
     const {t} = useTranslation('content-editor');
     const contentEditorConfigContext = useContentEditorConfigContext();
     const {nodeData, formQueryParams, initialValues, title} = useContentEditorContext();
     const {sections} = useContentEditorSectionContext();
+
+    useEffect(() => {
+        return () => {
+            if (window.authoringApi.refreshContent) {
+                window.authoringApi.refreshContent();
+            }
+        };
+    }, []);
 
     const handleSubmit = (values, actions) => {
         createNode({
@@ -71,12 +79,10 @@ const CreateCmp = ({
 };
 
 CreateCmp.propTypes = {
-    client: PropTypes.object.isRequired,
     notificationContext: PropTypes.object.isRequired
 };
 
 export const Create = compose(
-    withApollo,
     withNotifications(),
     withContentEditorDataContextProvider(FormQuery, adaptCreateFormData)
 )(CreateCmp);

--- a/src/javascript/Edit/Edit.jsx
+++ b/src/javascript/Edit/Edit.jsx
@@ -91,7 +91,7 @@ export const EditCmp = ({
                     {() => <EditPanel title={title}/>}
                 </Formik>
             </PublicationInfoContextProvider>
-            {!nodeData.lockedAndCannotBeEdited && <LockManager uuid={nodeData.uuid}/>}
+            {!nodeData.lockedAndCannotBeEdited && <LockManager uuid={nodeData.uuid} onLockReleased={window.authoringApi.refreshContent}/>}
         </>
     );
 };

--- a/src/javascript/Edit/Edit.jsx
+++ b/src/javascript/Edit/Edit.jsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect} from 'react';
 import {withNotifications} from '@jahia/react-material';
 import {Formik} from 'formik';
 import EditPanel from '~/EditPanel';
@@ -34,7 +34,18 @@ export const EditCmp = ({
     const {sections} = useContentEditorSectionContext();
     const dispatch = useDispatch();
 
+    useEffect(() => {
+        return () => {
+            // If nodeData.lockedAndCannotBeEdited, rely on callback after lock released
+            if (nodeData.lockedAndCannotBeEdited && contentEditorConfigContext.envProps.onClosedCallback) {
+                contentEditorConfigContext.envProps.onClosedCallback();
+            }
+        };
+    }, [contentEditorConfigContext.envProps, nodeData.lockedAndCannotBeEdited]);
+
     const handleSubmit = useCallback((values, actions) => {
+        contentEditorConfigContext.envProps.isNeedRefresh = true;
+
         saveNode({
             client,
             t,
@@ -91,7 +102,7 @@ export const EditCmp = ({
                     {() => <EditPanel title={title}/>}
                 </Formik>
             </PublicationInfoContextProvider>
-            {!nodeData.lockedAndCannotBeEdited && <LockManager uuid={nodeData.uuid} onLockReleased={window.authoringApi.refreshContent}/>}
+            {!nodeData.lockedAndCannotBeEdited && <LockManager uuid={nodeData.uuid} onLockReleased={contentEditorConfigContext.envProps.onClosedCallback}/>}
         </>
     );
 };

--- a/src/javascript/Lock/LockManager.js
+++ b/src/javascript/Lock/LockManager.js
@@ -4,7 +4,7 @@ import {useApolloClient} from '@apollo/react-hooks';
 import {SubscribeToEditorLock} from './lock.gql-subscription';
 import {UnlockEditorMutation} from './lock.gql-mutation';
 
-export const LockManager = ({uuid}) => {
+export const LockManager = ({uuid, onLockReleased}) => {
     const client = useApolloClient();
 
     useEffect(() => {
@@ -43,18 +43,18 @@ export const LockManager = ({uuid}) => {
                     // Manual refetch to avoid node displayed as locked in other apps like (Jcontent)
                     client.reFetchObservableQueries();
 
-                    // Manual refresh GWT content to avoid page composer left tree node displayed as locked
-                    if (window.authoringApi.refreshContent) {
-                        window.authoringApi.refreshContent();
+                    if (onLockReleased) {
+                        onLockReleased();
                     }
                 })
                 .catch(err => console.error(err));
         };
-    }, [client, uuid]);
+    }, [client, uuid, onLockReleased]);
 
     return '';
 };
 
 LockManager.propTypes = {
+    onLockReleased: PropTypes.func,
     uuid: PropTypes.string.isRequired
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13660

## Description

Adds a onClosedCallback that is called when the engine is completely closed (and locks released, if any)
In edit mode, refresh only when the lock has been released. If no lock is set, it means the content was in readonly and therefore no need to reload.
In create mode, refresh when the Create is closed. If Create is closed to open an Edit (when clicking on save), refresh is not called - it's done only when the Edit dialog is closed.
