### PR TITLE
BACKLOG-16829: Update content editor closing modals

### DIFF
--- a/src/javascript/Api/ContentEditor.api.jsx
+++ b/src/javascript/Api/ContentEditor.api.jsx
@@ -250,7 +250,6 @@ const ContentEditorApiCmp = ({classes, client}) => {
                         <FormikProvider value={formikRef.current}>
                             <EditPanelDialogConfirmation
                                 isOpen={open}
-                                titleKey="content-editor:label.contentEditor.edit.action.goBack.title"
                                 actionCallback={envProps.back}
                                 onCloseDialog={() => setConfirmationConfig(false)}
                             />

--- a/src/javascript/Edit/engineTabs/openEngineTabs.action.jsx
+++ b/src/javascript/Edit/engineTabs/openEngineTabs.action.jsx
@@ -14,8 +14,11 @@ export const OpenEngineTabs = ({tabs, render: Render, ...otherProps}) => {
         <>
             <EditPanelDialogConfirmation
                 isOpen={open}
-                actionCallback={() => {
-                    formik.resetForm(formik.values);
+                actionCallback={(overrideStoredLocation, discard) => {
+                    if (discard) {
+                        formik.resetForm();
+                    }
+
                     openEngineTab(nodeData, tabs);
                 }}
                 onCloseDialog={() => setOpen(false)}

--- a/src/javascript/Edit/engineTabs/openEngineTabs.action.jsx
+++ b/src/javascript/Edit/engineTabs/openEngineTabs.action.jsx
@@ -14,7 +14,6 @@ export const OpenEngineTabs = ({tabs, render: Render, ...otherProps}) => {
         <>
             <EditPanelDialogConfirmation
                 isOpen={open}
-                titleKey="content-editor:label.contentEditor.edit.action.goBack.title"
                 actionCallback={() => {
                     formik.resetForm(formik.values);
                     openEngineTab(nodeData, tabs);

--- a/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
+++ b/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {Dialog, DialogActions, DialogContent, DialogTitle} from '@material-ui/core';
 import {Button, Typography} from '@jahia/moonstone';
 import * as PropTypes from 'prop-types';
@@ -6,8 +6,23 @@ import {useTranslation} from 'react-i18next';
 import {SaveButton} from '~/EditPanel/EditPanelDialogConfirmation/SaveButton';
 import classes from './EditPanelDialogConfirmation.scss';
 
-export const EditPanelDialogConfirmation = React.memo(({isOpen, onCloseDialog, actionCallback}) => {
+const useDialogKey = switchLang => {
+    const rootProp = 'content-editor:label.contentEditor.edit.action.goBack';
+    const [titleKey] = useState(`${rootProp}.edit.title`);
+    const [messageKey, setMessageKey] = useState(`${rootProp}.edit.message`);
+
+    useEffect(() => {
+        if (switchLang) {
+            setMessageKey(`${rootProp}.edit.switchLanguage`);
+        }
+    }, [switchLang]);
+
+    return {titleKey, messageKey};
+};
+
+export const EditPanelDialogConfirmation = React.memo(({isOpen, switchLang = false, onCloseDialog, actionCallback}) => {
     const {t} = useTranslation('content-editor');
+    const {titleKey, messageKey} = useDialogKey(switchLang);
     const handleDiscard = () => {
         onCloseDialog();
 
@@ -15,9 +30,6 @@ export const EditPanelDialogConfirmation = React.memo(({isOpen, onCloseDialog, a
         // True: byPassEventTriggers (we dont want to perform event triggers in case of nothing have been saved/created)
         actionCallback(undefined, true);
     };
-
-    const titleKey = 'content-editor:label.contentEditor.edit.action.goBack.edit.title';
-    const messageKey = 'content-editor:label.contentEditor.edit.action.goBack.edit.message';
 
     return (
         <Dialog
@@ -56,6 +68,7 @@ EditPanelDialogConfirmation.name = 'EditPanelDialogConfirmation';
 
 EditPanelDialogConfirmation.propTypes = {
     isOpen: PropTypes.bool.isRequired,
+    switchLang: PropTypes.bool,
     actionCallback: PropTypes.func.isRequired,
     onCloseDialog: PropTypes.func.isRequired
 };

--- a/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
+++ b/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import {Dialog, DialogActions, DialogTitle} from '@material-ui/core';
-import {Button} from '@jahia/moonstone';
+import {Dialog, DialogActions, DialogContent, DialogTitle} from '@material-ui/core';
+import {Button, Typography} from '@jahia/moonstone';
 import * as PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {SaveButton} from '~/EditPanel/EditPanelDialogConfirmation/SaveButton';
+import classes from './EditPanelDialogConfirmation.scss';
 
-export const EditPanelDialogConfirmation = React.memo(({titleKey, isOpen, onCloseDialog, actionCallback}) => {
+export const EditPanelDialogConfirmation = React.memo(({isOpen, onCloseDialog, actionCallback}) => {
     const {t} = useTranslation('content-editor');
     const handleDiscard = () => {
         onCloseDialog();
@@ -14,6 +15,9 @@ export const EditPanelDialogConfirmation = React.memo(({titleKey, isOpen, onClos
         // True: byPassEventTriggers (we dont want to perform event triggers in case of nothing have been saved/created)
         actionCallback(undefined, true);
     };
+
+    const titleKey = 'content-editor:label.contentEditor.edit.action.goBack.edit.title';
+    const messageKey = 'content-editor:label.contentEditor.edit.action.goBack.edit.message';
 
     return (
         <Dialog
@@ -25,9 +29,15 @@ export const EditPanelDialogConfirmation = React.memo(({titleKey, isOpen, onClos
             <DialogTitle id="alert-dialog-slide-title">
                 {t(titleKey)}
             </DialogTitle>
+            <DialogContent className={classes.dialogContent}>
+                <Typography>
+                    {t(messageKey)}
+                </Typography>
+            </DialogContent>
             <DialogActions>
                 <Button
                     size="big"
+                    variant="ghost"
                     label={t('content-editor:label.contentEditor.edit.action.goBack.btnContinue')}
                     onClick={onCloseDialog}
                 />
@@ -45,7 +55,6 @@ export const EditPanelDialogConfirmation = React.memo(({titleKey, isOpen, onClos
 EditPanelDialogConfirmation.name = 'EditPanelDialogConfirmation';
 
 EditPanelDialogConfirmation.propTypes = {
-    titleKey: PropTypes.string.isRequired,
     isOpen: PropTypes.bool.isRequired,
     actionCallback: PropTypes.func.isRequired,
     onCloseDialog: PropTypes.func.isRequired

--- a/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
+++ b/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
@@ -5,24 +5,36 @@ import * as PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {SaveButton} from '~/EditPanel/EditPanelDialogConfirmation/SaveButton';
 import classes from './EditPanelDialogConfirmation.scss';
+import {useContentEditorContext} from '~/ContentEditor.context';
+import {Constants} from '~/ContentEditor.constants';
 
-const useDialogKey = switchLang => {
+/**
+ * Build title key and dialog message key depending on the mode and switchLang flag
+ * @returns {{messageKey: string, titleKey: string}}
+ */
+const useDialogText = (switchLang, mode) => {
     const rootProp = 'content-editor:label.contentEditor.edit.action.goBack';
-    const [titleKey] = useState(`${rootProp}.edit.title`);
+    const [titleKey, setTitleKey] = useState(`${rootProp}.edit.title`);
     const [messageKey, setMessageKey] = useState(`${rootProp}.edit.message`);
 
     useEffect(() => {
-        if (switchLang) {
-            setMessageKey(`${rootProp}.edit.switchLanguage`);
+        const isEditMode = mode === Constants.routes.baseEditRoute;
+        if (switchLang || !isEditMode) {
+            const messageKey = (switchLang) ? 'switchLanguage' : 'message';
+            setMessageKey(`${rootProp}.${mode}.${messageKey}`);
+            if (!isEditMode) {
+                setTitleKey(`${rootProp}.${mode}.title`);
+            }
         }
-    }, [switchLang]);
+    }, [switchLang, mode]);
 
     return {titleKey, messageKey};
 };
 
 export const EditPanelDialogConfirmation = React.memo(({isOpen, switchLang = false, onCloseDialog, actionCallback}) => {
     const {t} = useTranslation('content-editor');
-    const {titleKey, messageKey} = useDialogKey(switchLang);
+    const {mode, lang, siteInfo} = useContentEditorContext();
+    const {titleKey, messageKey} = useDialogText(switchLang, mode);
     const handleDiscard = () => {
         onCloseDialog();
 
@@ -31,6 +43,7 @@ export const EditPanelDialogConfirmation = React.memo(({isOpen, switchLang = fal
         actionCallback(undefined, true);
     };
 
+    const langName = siteInfo.languages.find(l => l.language === lang)?.displayName;
     return (
         <Dialog
             maxWidth="md"
@@ -43,7 +56,7 @@ export const EditPanelDialogConfirmation = React.memo(({isOpen, switchLang = fal
             </DialogTitle>
             <DialogContent className={classes.dialogContent}>
                 <Typography>
-                    {t(messageKey)}
+                    {t(messageKey, {langName})}
                 </Typography>
             </DialogContent>
             <DialogActions>

--- a/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.scss
+++ b/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.scss
@@ -1,0 +1,6 @@
+div.dialogContent {
+    padding-top: var(--spacing-large);
+    padding-bottom: var(--spacing-large);
+
+    border-bottom: 1px solid var(--color-gray_light40);
+}

--- a/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.spec.jsx
+++ b/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.spec.jsx
@@ -13,7 +13,6 @@ describe('EditPanelDialogConfirmation', () => {
     beforeEach(() => {
         defaultProps = {
             isOpen: false,
-            titleKey: 'titleKey',
             t: jest.fn(key => 'translated_' + key),
             onCloseDialog: jest.fn(),
             actionCallback: jest.fn()
@@ -39,7 +38,7 @@ describe('EditPanelDialogConfirmation', () => {
             dsGenericTheme
         ).dive();
 
-        expect(cmp.debug()).toContain('translated_' + defaultProps.titleKey);
+        expect(cmp.debug()).toContain('translated_');
     });
 
     it('should show dialog confirmation when open is true', () => {

--- a/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.spec.jsx
+++ b/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.spec.jsx
@@ -3,8 +3,10 @@ import {shallowWithTheme} from '@jahia/test-framework';
 import {dsGenericTheme} from '@jahia/design-system-kit';
 import {EditPanelDialogConfirmation} from './';
 import {useFormikContext} from 'formik';
+import {useContentEditorContext} from '~/ContentEditor.context';
 
 jest.mock('formik');
+jest.mock('~/ContentEditor.context', () => ({useContentEditorContext: jest.fn()}));
 
 describe('EditPanelDialogConfirmation', () => {
     let defaultProps;
@@ -19,6 +21,14 @@ describe('EditPanelDialogConfirmation', () => {
         };
         formik = {};
         useFormikContext.mockReturnValue(formik);
+        useContentEditorContext.mockImplementation(() => ({
+            lang: 'en',
+            siteInfo: {
+                languages: [{
+                    language: 'en', displayName: 'English'
+                }]
+            }
+        }));
     });
 
     it('should hide dialog confirmation when open is false', () => {

--- a/src/javascript/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
+++ b/src/javascript/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
@@ -58,8 +58,8 @@ const EditPanelLanguageSwitcher = ({siteInfo}) => {
             />
 
             <EditPanelDialogConfirmation
+                switchLang
                 isOpen={dialogConfirmation.open}
-                titleKey="content-editor:label.contentEditor.switchLanguage.dialog.title"
                 actionCallback={actionCallback}
                 onCloseDialog={onCloseDialog}
             />

--- a/src/javascript/EditPanel/header/ContentBreadcrumb/ContentPath/ContentPath.container.jsx
+++ b/src/javascript/EditPanel/header/ContentBreadcrumb/ContentPath/ContentPath.container.jsx
@@ -112,7 +112,6 @@ const ContentPathContainer = ({path, uuid, operator}) => {
         <>
             <EditPanelDialogConfirmation
                 isOpen={open}
-                titleKey="content-editor:label.contentEditor.edit.action.goBack.title"
                 actionCallback={actionCallback}
                 onCloseDialog={onCloseDialog}
             />

--- a/src/javascript/actions/goBack.action.jsx
+++ b/src/javascript/actions/goBack.action.jsx
@@ -41,7 +41,6 @@ const GoBack = ({render: Render, componentProps, ...otherProps}) => {
         <>
             <EditPanelDialogConfirmation
                 isOpen={open}
-                titleKey="content-editor:label.contentEditor.edit.action.goBack.title"
                 actionCallback={executeGoBackAction}
                 onCloseDialog={onCloseDialog}
             />

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -40,9 +40,18 @@
           },
           "goBack": {
             "name": "Zurück zu {{parentNodeDisplayName}}",
-            "title": "Änderungen vor dem Schließen speichern?",
+            "edit": {
+              "title": "Nicht gespeicherte Änderungen",
+              "message": "Änderungen wurden noch nicht gespeichert. Was möchten Sie vor dem Schließen tun?",
+              "switchLanguage": "Änderungen wurden noch nicht gespeichert. Was möchten Sie vor dem Wechsel zur anderen Sprache tun?"
+            },
+            "create": {
+              "title": "Nicht gespeicherter Content",
+              "message": "Änderungen wurden noch nicht gespeichert. Was möchten Sie vor dem Schließen tun?",
+              "switchLanguage": "Der Content wurde noch nicht in {{langName}} gespeichert. Was möchten Sie vor dem Wechsel zur anderen Sprache tun?"
+            },
             "alert": "Von Ihnen vorgenommene Änderungen werden nicht gespeichert.",
-            "btnContinue": "Weiter bearbeiten",
+            "btnContinue": "Abbrechen",
             "btnDiscard": "Änderungen verwerfen",
             "btnSave": "Änderungen speichern"
           },

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -47,8 +47,8 @@
             },
             "create": {
               "title": "Unsaved content",
-              "message": "The content is not yet saved in {{currentLang}}. What do you want to do before closing?",
-              "switchLanguage": "The content is not yet saved in {{currentLang}}. What do you want to do before switching language?"
+              "message": "The content is not yet saved in {{langName}}. What do you want to do before closing?",
+              "switchLanguage": "The content is not yet saved in {{langName}}. What do you want to do before switching language?"
             },
             "alert": "Changes that you made will not be saved.",
             "btnContinue": "Cancel",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -47,7 +47,7 @@
             },
             "create": {
               "title": "Unsaved content",
-              "message": "The content is not yet saved in {{langName}}. What do you want to do before closing?",
+              "message": "The content is not yet saved. What do you want to do before closing?",
               "switchLanguage": "The content is not yet saved in {{langName}}. What do you want to do before switching language?"
             },
             "alert": "Changes that you made will not be saved.",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -40,11 +40,20 @@
           },
           "goBack": {
             "name": "Back to {{parentNodeDisplayName}}",
-            "title": "Save changes before closing?",
+            "edit": {
+              "title": "Unsaved changes",
+              "message": "There are unsaved changes. What do you want to do with them before closing?",
+              "switchLanguage": "There are unsaved changes. What do you want to do with them before switching language?"
+            },
+            "create": {
+              "title": "Unsaved content",
+              "message": "The content is not yet saved in {{currentLang}}. What do you want to do before closing?",
+              "switchLanguage": "The content is not yet saved in {{currentLang}}. What do you want to do before switching language?"
+            },
             "alert": "Changes that you made will not be saved.",
-            "btnContinue": "Continue editing",
-            "btnDiscard": "Discard changes",
-            "btnSave": "Save changes"
+            "btnContinue": "Cancel",
+            "btnDiscard": "Discard",
+            "btnSave": "Save"
           },
           "lock": {
             "deletion": "Locked: marked for deletion",
@@ -174,11 +183,6 @@
       "header":  {
         "chips": {
           "unsavedLabel": "Unsaved changes"
-        }
-      },
-      "switchLanguage": {
-        "dialog": {
-          "title": "Save changes before switching language?"
         }
       },
       "error": {

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -40,11 +40,20 @@
           },
           "goBack": {
             "name": "Retour à {{parentNodeDisplayName}}",
-            "title": "Enregistrer les modifications avant de fermer ?",
+            "edit": {
+              "title": "Modifications non sauvegardées",
+              "message": "Vous avez des modifications non sauvegardées. Que souhaitez-vous faire avant de fermer?",
+              "switchLanguage": "Vous avez des modifications non sauvegardées. Que souhaitez-vous faire avant de changer de langue?"
+            },
+            "create": {
+              "title": "Contenu non sauvegardé",
+              "message": "Le contenu n'a pas été sauvegardé. Que souhaitez-vous faire avant de fermer ?",
+              "switchLanguage": "Le contenu n'a pas été sauvegardé en {{langName}}. Que souhaitez-vous faire avant de changer de langue ?"
+            },
             "alert": "Les modifications que vous avez apportées ne seront pas enregistrées.",
-            "btnContinue": "Poursuivre la modification",
-            "btnDiscard": "Abandonner les modifications",
-            "btnSave": "Enregistrer les modifications"
+            "btnContinue": "Annuler",
+            "btnDiscard": "Fermer sans sauver",
+            "btnSave": "Sauvegarder"
           },
           "lock": {
             "deletion": "Vérouillé: Contenu marqué pour suppression",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16829

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Styled closing modal dialogs
* Added logic within dialog component to determine title and messaged displayed; translations
* Updated tests
* Fix issue with saving with closing modals on _Advanced options_ tabs
