### PR TITLE
BACKLOG-16486: Skip locking

### DIFF
--- a/src/javascript/Edit/engineTabs/engineTabs.utils.js
+++ b/src/javascript/Edit/engineTabs/engineTabs.utils.js
@@ -29,7 +29,8 @@ export function openEngineTab(nodeData, engineTabs) {
         {
             hideWip: true,
             displayedTabs: engineTabs,
-            hideHeaders: true
+            hideHeaders: true,
+            skipLock: true
         }
     );
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16486

## Description

Prevent locking twice the node, as we are already in content-editor with a global lock on the current node. Since locks are not reentrant, opening an advanced tab tries to add another lock without success, but closing it remove the content-editor lock.