### PR TITLE
BACKLOG-16829: Fix out-of-sync formik values; Handle 'no-CE context' scenarios

### DIFF
--- a/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
+++ b/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
@@ -21,6 +21,7 @@ const useDialogText = (switchLang, mode) => {
         const isEditMode = mode === Constants.routes.baseEditRoute;
         if (switchLang || !isEditMode) {
             const messageKey = (switchLang) ? 'switchLanguage' : 'message';
+            mode = mode || 'edit';
             setMessageKey(`${rootProp}.${mode}.${messageKey}`);
             if (!isEditMode) {
                 setTitleKey(`${rootProp}.${mode}.title`);
@@ -43,7 +44,7 @@ export const EditPanelDialogConfirmation = React.memo(({isOpen, switchLang = fal
         actionCallback(undefined, true);
     };
 
-    const langName = siteInfo.languages.find(l => l.language === lang)?.displayName;
+    const langName = siteInfo?.languages?.find(l => l.language === lang)?.displayName || '';
     return (
         <Dialog
             maxWidth="md"

--- a/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
+++ b/src/javascript/EditPanel/EditPanelDialogConfirmation/EditPanelDialogConfirmation.jsx
@@ -21,10 +21,10 @@ const useDialogText = (switchLang, mode) => {
         const isEditMode = mode === Constants.routes.baseEditRoute;
         if (switchLang || !isEditMode) {
             const messageKey = (switchLang) ? 'switchLanguage' : 'message';
-            mode = mode || 'edit';
-            setMessageKey(`${rootProp}.${mode}.${messageKey}`);
+            const modeKey = mode || 'edit';
+            setMessageKey(`${rootProp}.${modeKey}.${messageKey}`);
             if (!isEditMode) {
-                setTitleKey(`${rootProp}.${mode}.title`);
+                setTitleKey(`${rootProp}.${modeKey}.title`);
             }
         }
     }, [switchLang, mode]);

--- a/src/javascript/EditPanel/EditPanelDialogConfirmation/SaveButton.jsx
+++ b/src/javascript/EditPanel/EditPanelDialogConfirmation/SaveButton.jsx
@@ -13,7 +13,10 @@ export const SaveButton = ({onCloseDialog, actionCallback}) => {
 
         // Override default submit callback to execute the confirmation callback instead
         formik.setFieldValue(Constants.systemFields.OVERRIDE_SUBMIT_CALLBACK, actionCallback, false);
-        formik.submitForm();
+        formik.submitForm()
+            .then(() => {
+                formik.resetForm({values: formik.values});
+            });
     };
 
     let disabled = false;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16829

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix some bugs:

* when closing modal is open and clicking outside of content-editor (e.g. click on primary nav), CE context is undefined in this case. Add default values in this case.
* Closing modal still pops up even after save from a previous closing modal. This is because formik dirty flag is not reset. Refresh formik values after submit to clear dirty flag.