### PR TITLE
BACKLOG-16835: Enable CE modal in edit mode

### DIFF
--- a/src/javascript/ContentEditor.register.jsx
+++ b/src/javascript/ContentEditor.register.jsx
@@ -54,7 +54,7 @@ export default function () {
     window.top.jahiaGwtHook = {
         // Hook on edit engine opening
         edit: ({uuid, lang, siteKey, uilang}) => {
-            window.CE_API.edit(uuid, siteKey, lang, uilang, true, (updatedNode, originalNode) => {
+            window.CE_API.edit(uuid, siteKey, lang, uilang, false, (updatedNode, originalNode) => {
                 // Trigger Page Composer to reload iframe if system name was renamed
                 if (originalNode.path !== updatedNode.path) {
                     const dispatch = window.jahia.reduxStore.dispatch;

--- a/src/javascript/EditPanel/EditPanelCompact.jsx
+++ b/src/javascript/EditPanel/EditPanelCompact.jsx
@@ -12,10 +12,7 @@ import {GoBack} from '~/actions/goBack.action';
 import {getButtonRenderer} from '~/utils/getButtonRenderer';
 import {EditPanelLanguageSwitcher} from '~/EditPanel/EditPanelLanguageSwitcher';
 import {useTranslation} from 'react-i18next';
-import PublicationInfoBadge from '~/PublicationInfo/PublicationInfo.badge';
-import LockInfoBadge from '~/Lock/LockInfo.badge';
-import WipInfoChip from '~/EditPanel/WorkInProgress/Chip/WipInfo.Chip';
-import {UnsavedChip} from '~/EditPanel/header';
+import HeaderBadges from '~/EditPanel/header/HeaderBadges';
 
 const ButtonRenderer = getButtonRenderer({
     defaultButtonProps: {size: 'big', className: styles.saveButtons},
@@ -58,12 +55,7 @@ const EditPanelCompact = ({title, createAnother}) => {
                     { mode === 'edit' &&
                         <>
                             <div className="flexFluid"/>
-                            <div>
-                                <PublicationInfoBadge/>
-                                <LockInfoBadge/>
-                                <WipInfoChip/>
-                                <UnsavedChip/>
-                            </div>
+                            <HeaderBadges/>
                         </>}
                 </div>
             </DialogTitle>

--- a/src/javascript/EditPanel/EditPanelCompact.jsx
+++ b/src/javascript/EditPanel/EditPanelCompact.jsx
@@ -12,6 +12,10 @@ import {GoBack} from '~/actions/goBack.action';
 import {getButtonRenderer} from '~/utils/getButtonRenderer';
 import {EditPanelLanguageSwitcher} from '~/EditPanel/EditPanelLanguageSwitcher';
 import {useTranslation} from 'react-i18next';
+import PublicationInfoBadge from '~/PublicationInfo/PublicationInfo.badge';
+import LockInfoBadge from '~/Lock/LockInfo.badge';
+import WipInfoChip from '~/EditPanel/WorkInProgress/Chip/WipInfo.Chip';
+import {UnsavedChip} from '~/EditPanel/header';
 
 const ButtonRenderer = getButtonRenderer({
     defaultButtonProps: {size: 'big', className: styles.saveButtons},
@@ -19,7 +23,7 @@ const ButtonRenderer = getButtonRenderer({
 });
 
 const EditPanelCompact = ({title, createAnother}) => {
-    const {siteInfo, nodeData, lang} = useContentEditorContext();
+    const {siteInfo, nodeData, lang, mode} = useContentEditorContext();
     const contentEditorConfigContext = useContentEditorConfigContext();
     const {t} = useTranslation('content-editor');
 
@@ -51,6 +55,16 @@ const EditPanelCompact = ({title, createAnother}) => {
                 </div>
                 <div className={clsx('flexRow', styles.languageSwitcher)}>
                     <EditPanelLanguageSwitcher lang={lang} siteInfo={siteInfo}/>
+                    { mode === 'edit' &&
+                        <>
+                            <div className="flexFluid"/>
+                            <div>
+                                <PublicationInfoBadge/>
+                                <LockInfoBadge/>
+                                <WipInfoChip/>
+                                <UnsavedChip/>
+                            </div>
+                        </>}
                 </div>
             </DialogTitle>
             <DialogContent className="flexCol" id="contenteditor-dialog-content" data-sel-role="form-container">

--- a/src/javascript/EditPanel/header/HeaderBadges/HeaderBadges.jsx
+++ b/src/javascript/EditPanel/header/HeaderBadges/HeaderBadges.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import PublicationInfoBadge from '~/PublicationInfo/PublicationInfo.badge';
+import LockInfoBadge from '~/Lock/LockInfo.badge';
+import WipInfoChip from '~/EditPanel/WorkInProgress/Chip/WipInfo.Chip';
+import {UnsavedChip} from '~/EditPanel/header';
+
+const HeaderBadges = () => (
+    <div>
+        <PublicationInfoBadge/>
+        <LockInfoBadge/>
+        <WipInfoChip/>
+        <UnsavedChip/>
+    </div>
+);
+
+export default HeaderBadges;

--- a/src/javascript/EditPanel/header/HeaderBadges/HeaderBadges.spec.jsx
+++ b/src/javascript/EditPanel/header/HeaderBadges/HeaderBadges.spec.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {shallow} from '@jahia/test-framework';
+import HeaderBadges from './';
+import {Constants} from '~/ContentEditor.constants';
+import {useFormikContext} from 'formik';
+import {useContentEditorContext} from '~/ContentEditor.context';
+
+jest.mock('~/ContentEditor.context');
+jest.mock('formik');
+describe('Header UpperSection', () => {
+    let formik;
+    let contentEditorContext;
+
+    beforeEach(() => {
+        contentEditorContext = {
+            mode: 'create',
+            nodeData: {
+                primaryNodeType: {
+                    displayName: 'WIP-WOP'
+                }
+            }
+        };
+        useContentEditorContext.mockReturnValue(contentEditorContext);
+        formik = {
+            values: {
+                'WIP::Info': {
+                    status: Constants.wip.status.DISABLED
+                }
+            }
+        };
+        useFormikContext.mockReturnValue(formik);
+    });
+
+    it('should u and unsaved info chip displayed when ce in create mode', () => {
+        const cmp = shallow(<HeaderBadges/>);
+        expect(cmp.find('UnsavedChip').dive().find({'data-sel-role': 'unsaved-info-chip'}).exists()).toBe(true);
+    });
+});

--- a/src/javascript/EditPanel/header/HeaderBadges/index.js
+++ b/src/javascript/EditPanel/header/HeaderBadges/index.js
@@ -1,0 +1,3 @@
+import HeaderBadges from './HeaderBadges';
+
+export default HeaderBadges;

--- a/src/javascript/EditPanel/header/UpperSection.jsx
+++ b/src/javascript/EditPanel/header/UpperSection.jsx
@@ -24,7 +24,7 @@ const BackButtonRenderer = getButtonRenderer({
 });
 
 export const HeaderUpperSection = ({title, isShowPublish}) => {
-    const {nodeData, nodeTypeDisplayName} = useContentEditorContext();
+    const {nodeData, nodeTypeDisplayName, mode} = useContentEditorContext();
 
     return (
         <>
@@ -72,7 +72,7 @@ export const HeaderUpperSection = ({title, isShowPublish}) => {
                         <ContentBreadcrumb path={nodeData.path}/> :
                         <Chip label={nodeTypeDisplayName} color="accent"/>}
                 </div>
-                <HeaderBadges className={styles.headerChips}/>
+                {mode === 'edit' && <HeaderBadges className={styles.headerChips}/>}
             </div>
         </>
     );

--- a/src/javascript/EditPanel/header/UpperSection.jsx
+++ b/src/javascript/EditPanel/header/UpperSection.jsx
@@ -3,16 +3,13 @@ import PropTypes from 'prop-types';
 
 import {ButtonGroup, Chip, Typography} from '@jahia/moonstone';
 import {DisplayAction, DisplayActions} from '@jahia/ui-extender';
-import PublicationInfoBadge from '~/PublicationInfo/PublicationInfo.badge';
-import LockInfoBadge from '~/Lock/LockInfo.badge';
-import WipInfoChip from '~/EditPanel/WorkInProgress/Chip/WipInfo.Chip';
 import {truncate} from '~/utils/helper';
 import styles from './UpperSection.scss';
 import ContentBreadcrumb from '~/EditPanel/header/ContentBreadcrumb';
 import {useContentEditorContext} from '~/ContentEditor.context';
-import {UnsavedChip} from '~/EditPanel/header/UnsavedChip';
 import {PublishMenu} from '~/EditPanel/header/PublishMenu';
 import {getButtonRenderer} from '~/utils/getButtonRenderer';
+import HeaderBadges from '~/EditPanel/header/HeaderBadges/HeaderBadges';
 
 const ButtonRenderer = getButtonRenderer({
     defaultButtonProps: {
@@ -75,13 +72,7 @@ export const HeaderUpperSection = ({title, isShowPublish}) => {
                         <ContentBreadcrumb path={nodeData.path}/> :
                         <Chip label={nodeTypeDisplayName} color="accent"/>}
                 </div>
-
-                <div className={styles.headerChips}>
-                    <PublicationInfoBadge/>
-                    <LockInfoBadge/>
-                    <WipInfoChip/>
-                    <UnsavedChip/>
-                </div>
+                <HeaderBadges className={styles.headerChips}/>
             </div>
         </>
     );

--- a/src/javascript/EditPanel/header/UpperSection.spec.js
+++ b/src/javascript/EditPanel/header/UpperSection.spec.js
@@ -56,14 +56,4 @@ describe('Header UpperSection', () => {
 
         expect(cmp.debug()).toContain('yolo');
     });
-
-    it('should u and unsaved info chip displayed when ce in create mode', () => {
-        const cmp = shallowWithTheme(
-            <HeaderUpperSection {...defaultProps}/>,
-            {},
-            dsGenericTheme
-        );
-
-        expect(cmp.find('UnsavedChip').dive().find({'data-sel-role': 'unsaved-info-chip'}).exists()).toBe(true);
-    });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

* https://jira.jahia.org/browse/BACKLOG-16835
* https://jira.jahia.org/browse/BACKLOG-17125

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Enable CE modal when in edit mode
* Refactor header badges into a component
* Add badges in Edit panel modal
* BACKLOG-17125: Remove badges in CE fullscreen create mode