### PR TITLE
BACKLOG-17163: Remove edit actions in CE create mode

### DIFF
--- a/src/javascript/EditPanel/header/HeaderLowerSection.jsx
+++ b/src/javascript/EditPanel/header/HeaderLowerSection.jsx
@@ -10,37 +10,40 @@ import {useContentEditorContext} from '~/ContentEditor.context';
 
 export const HeaderLowerSection = ({setActiveTab, activeTab}) => {
     const {t} = useTranslation('content-editor');
-    const {siteInfo, lang, nodeData} = useContentEditorContext();
+    const {siteInfo, lang, nodeData, mode} = useContentEditorContext();
     return (
         <div className={styles.headerToolBar}>
             <EditPanelLanguageSwitcher lang={lang} siteInfo={siteInfo}/>
 
             <Separator variant="vertical" size="medium"/>
 
-            <Tab>
-                <DisplayActions
-                    setActiveTab={setActiveTab}
-                    activeTab={activeTab}
-                    target="editHeaderTabsActions"
-                    nodeData={nodeData}
-                    render={renderProps => {
-                        return (
-                            <TabItem
-                                data-sel-role={renderProps.dataSelRole}
-                                icon={renderProps.buttonIcon}
-                                label={t(renderProps.buttonLabel)}
-                                isSelected={renderProps.value === renderProps.activeTab}
-                                onClick={e => {
-                                    e.stopPropagation();
-                                    renderProps.onClick(renderProps, e);
-                                }}
-                            />
-                        );
-                    }}
-                />
-            </Tab>
-
-            <Separator variant="vertical" size="medium"/>
+            {(mode === 'edit') && (
+                <>
+                    <Tab>
+                        <DisplayActions
+                            setActiveTab={setActiveTab}
+                            activeTab={activeTab}
+                            target="editHeaderTabsActions"
+                            nodeData={nodeData}
+                            render={renderProps => {
+                                return (
+                                    <TabItem
+                                        data-sel-role={renderProps.dataSelRole}
+                                        icon={renderProps.buttonIcon}
+                                        label={t(renderProps.buttonLabel)}
+                                        isSelected={renderProps.value === renderProps.activeTab}
+                                        onClick={e => {
+                                            e.stopPropagation();
+                                            renderProps.onClick(renderProps, e);
+                                        }}
+                                    />
+                                );
+                            }}
+                        />
+                    </Tab>
+                    <Separator variant="vertical" size="medium"/>
+                </>
+            )}
 
             <DisplayAction
                 actionKey="content-editor/header/3dots"

--- a/src/javascript/EditPanel/header/HeaderLowerSection.spec.js
+++ b/src/javascript/EditPanel/header/HeaderLowerSection.spec.js
@@ -2,11 +2,28 @@ import React from 'react';
 import {shallowWithTheme} from '@jahia/test-framework';
 import {dsGenericTheme} from '@jahia/design-system-kit';
 import {HeaderLowerSection} from './';
+import {useContentEditorContext} from '~/ContentEditor.context';
 
+jest.mock('~/ContentEditor.context');
 describe('Header LowerSection', () => {
     let defaultProps;
+    let contentEditorContext;
 
     beforeEach(() => {
+        contentEditorContext = {
+            mode: 'create',
+            i18nContext: {},
+            nodeData: {
+                primaryNodeType: {
+                    displayName: 'WIP-WOP'
+                }
+            },
+            siteInfo: {
+                languages: [{name: 'en', displayName: 'english'}]
+            }
+        };
+        useContentEditorContext.mockReturnValue(contentEditorContext);
+
         defaultProps = {
             actionContext: {
                 siteInfo: {},
@@ -23,5 +40,24 @@ describe('Header LowerSection', () => {
             {},
             dsGenericTheme
         );
+    });
+
+    it('should not have edit tab items on create', () => {
+        const cmp = shallowWithTheme(
+            <HeaderLowerSection {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+        expect(cmp.find("Tab").exists()).toBeFalsy();
+    });
+
+    it('should have edit Tab Items on edit mode', () => {
+        contentEditorContext.mode = 'edit';
+        const cmp = shallowWithTheme(
+            <HeaderLowerSection {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+        expect(cmp.find("Tab").exists()).toBeTruthy();
     });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17163

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Remove edit action in the header lower section when CE is in create mode
- Added unit tests