### PR TITLE
QA-14323: JS localCompare issue

### DIFF
--- a/src/javascript/SelectorTypes/Category/category.adapter.js
+++ b/src/javascript/SelectorTypes/Category/category.adapter.js
@@ -2,8 +2,8 @@ export const adaptToCategoryTree = ({nodes, parent, selectedValues, locale}) => 
 
     // This is only to raise the issue, you will most likely want to fix it somewhere else and do something nicer as well.
     // localeCompare in JS expect a locale like en-US NOT en_US which Jahia uses.
-    if (locale.indexOf("_") !== -1) {
-        locale = locale.replace("_", "-");
+    if (locale.indexOf('_') !== -1) {
+        locale = locale.replace('_', '-');
     }
 
     return nodes

--- a/src/javascript/SelectorTypes/Category/category.adapter.js
+++ b/src/javascript/SelectorTypes/Category/category.adapter.js
@@ -1,4 +1,11 @@
 export const adaptToCategoryTree = ({nodes, parent, selectedValues, locale}) => {
+
+    // This is only to raise the issue, you will most likely want to fix it somewhere else and do something nicer as well.
+    // localeCompare in JS expect a locale like en-US NOT en_US which Jahia uses.
+    if (locale.indexOf("_") !== -1) {
+        locale = locale.replace("_", "-");
+    }
+
     return nodes
         .filter(category => category.parent.uuid === parent.uuid)
         .map(category => {

--- a/src/javascript/SelectorTypes/Category/category.adapter.js
+++ b/src/javascript/SelectorTypes/Category/category.adapter.js
@@ -1,6 +1,4 @@
 export const adaptToCategoryTree = ({nodes, parent, selectedValues, locale}) => {
-
-    // This is only to raise the issue, you will most likely want to fix it somewhere else and do something nicer as well.
     // localeCompare in JS expect a locale like en-US NOT en_US which Jahia uses.
     if (locale.indexOf('_') !== -1) {
         locale = locale.replace('_', '-');


### PR DESCRIPTION
## JIRA

There is a client ticket recently opened which lead me to this issue (MP for more details), there is a workaround but not really easy nor compatible with production so it's quite critical on our side.

## Environment
Jahia 8.1.0.1
Content-Editor 3.4.0

## Description
Create a website with a language country like `en_US` and another of your choice (it can simply be `en`)
Add the news module to the website.
Create a category in simple english `en` with 2 sub categories:
```
- Cat1
    - SubCat1
    - SubCat2
```
Go to page-composer to edit the website
Make sure you are editing in `en_US`
Add the component `Last news retrieving` => Error with localeCompare

This is because in JS localeCompare expect a locale to be dash separated not underscore. so it will work fine if you replace underscore by dash.

As commented in the file this PR is only to raise the issue, you will likely want to fix it somewhere else, in the mean time it would not hurt if you could provide a simple fix (like a content-editor 3.4.1) ;)