### PR TITLE
BACKLOG-17169: Removed ckeditor blur delay

### DIFF
--- a/src/javascript/SelectorTypes/RichText/RichText.jsx
+++ b/src/javascript/SelectorTypes/RichText/RichText.jsx
@@ -10,6 +10,8 @@ import {PickerDialog} from '~/SelectorTypes/Picker/PickerDialog';
 import {useTranslation} from 'react-i18next';
 import {buildPickerContext, fillCKEditorPicker} from './RichText.utils';
 
+window.CKEDITOR.focusManager._.blurDelay = 0;
+
 CKEditor.displayName = 'CKEditor';
 
 function loadOption(selectorOptions, name) {

--- a/src/javascript/SelectorTypes/RichText/RichText.jsx
+++ b/src/javascript/SelectorTypes/RichText/RichText.jsx
@@ -10,7 +10,9 @@ import {PickerDialog} from '~/SelectorTypes/Picker/PickerDialog';
 import {useTranslation} from 'react-i18next';
 import {buildPickerContext, fillCKEditorPicker} from './RichText.utils';
 
-window.CKEDITOR.focusManager._.blurDelay = 0;
+if (window.CKEDITOR) {
+    window.CKEDITOR.focusManager._.blurDelay = 0;
+}
 
 CKEditor.displayName = 'CKEditor';
 

--- a/src/javascript/Validation/validation.utils.js
+++ b/src/javascript/Validation/validation.utils.js
@@ -8,7 +8,7 @@ const setErrorFieldTouched = (errorsFields, setTouched) => {
             [field]: true
         };
     }, {});
-    return setTouched(fieldsTouched);
+    return setTouched(fieldsTouched, false);
 };
 
 export const validateForm = async ({setTouched, validateForm}, i18nContext, sections, language, siteInfo, componentRenderer) => {

--- a/src/javascript/Validation/validation.utils.spec.js
+++ b/src/javascript/Validation/validation.utils.spec.js
@@ -45,7 +45,7 @@ describe('validation utils', () => {
             expect(formik.setTouched).toHaveBeenCalledWith({
                 field1: true,
                 field2: true
-            });
+            }, false);
         });
 
         it('should display a modal when field have errors', async () => {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17169

## Description

Issue is due to ckeditor blur event revalidating the form after the server error has been received and parsed. By default ckeditor send blur event 200ms after effective blur, causing it to happen some times after server return .. removing the delay make it behave like other fields, sending the blur and triggering validation even before the save onclick event is received.
Also removed duplicate validation in setErrorFieldTouched.