### PR TITLE
QA-14309: Fix language mismatch when publishing node

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
@@ -198,7 +198,7 @@ public class EditorFormServiceImpl implements EditorFormService {
 
         // Filter the publication infos to only keep current node and sub technical nodes associated to the current node
         Collection<ComplexPublicationService.FullPublicationInfo> filteredInfos = publicationService.getFullPublicationInfos(Collections.singleton(uuid),
-                Collections.singletonList(locale.toLanguageTag()), false, session)
+                Collections.singletonList(locale.toString()), false, session)
             .stream()
             .filter(info -> info.getPublicationStatus() != PublicationInfo.DELETED) // keep only not deleted nodes
             .filter(ComplexPublicationService.FullPublicationInfo::isAllowedToPublishWithoutWorkflow) // keep only nodes allowed to bypass workflow


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14309

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix mismatch between the official locale name/tag and the locale suffix for a translation node.

While `toLanguageTag()` returns the correct IETF standard locale string e.g. `de-AT`, the suffix we use for translation nodes uses the de-facto string representation for locale with `_` separators e.g. `j:translation_de_AT` which fails comparison in [JCRPublicationService](https://github.com/Jahia/jahia-private/blob/master/core/src/main/java/org/jahia/services/content/JCRPublicationService.java#L1305) and ends up with translation node being filtered out and not published.

Use underscore locale format to match JCR format.


