### PR TITLE
BACKLOG-17228: Flag field has touched during onChange instead of only…

### DIFF
--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
@@ -75,10 +75,14 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
 
         // Trigger on changes
         registeredOnChange(currentValue);
-    }, [field.name, registeredOnChange, setFieldValue]);
+
+        setFieldTouched(field.name, true, false);
+    }, [field.name, registeredOnChange, setFieldValue, setFieldTouched]);
 
     const onBlur = useCallback(() => {
-        setFieldTouched(field.name);
+        if (onChangeValue.current !== initialValue.current) {
+            setFieldTouched(field.name);
+        }
     }, [field.name, setFieldTouched]);
 
     const registeredOnChangeRef = useRef(registeredOnChange);
@@ -217,4 +221,3 @@ Field.propTypes = {
     }).isRequired,
     field: FieldPropTypes.isRequired
 };
-


### PR DESCRIPTION
… onBlur. onBlur will happen before click event and we will lose click event if there is a redrawing

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17228

## Description

Avoid modifying structure during onBlur, so flag fields as touched during onChange event as we do for SystemName
I left the setFieldTouched in onBlur as it will help us detect weird behaviour on some fields and fix them

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
