### PR TITLE
BACKLOG-17311: Ensure we have a key for 'Picker'

### DIFF
--- a/src/javascript/SelectorTypes/Picker/registerPicker.js
+++ b/src/javascript/SelectorTypes/Picker/registerPicker.js
@@ -19,6 +19,7 @@ export const getPickerSelectorType = (registry, options) => {
     return ({
         cmp: Picker,
         supportsMultiple: false,
+        key: 'Picker',
         pickerConfig
     });
 };

--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
@@ -41,6 +41,7 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
     const errorArgs = splitError && splitError.length > 1 ? splitError.splice(1) : [];
     const hasMandatoryError = shouldDisplayErrors && errors[field.name] === 'required';
     const wipInfo = values[Constants.wip.fieldName];
+    const pickerType = selectorType.pickerConfig?.key;
 
     // Lookup for registered on changes for given field selector type
     const registeredOnChanges = useMemo(() => [...registry.find({
@@ -113,6 +114,7 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
              data-first-field={firstField}
              data-sel-content-editor-field={field.name}
              data-sel-content-editor-field-type={seleniumFieldType}
+             data-sel-content-editor-field-picker-type={pickerType}
              data-sel-content-editor-field-readonly={field.readOnly}
         >
             <div className="flexFluid">
@@ -219,7 +221,8 @@ Field.propTypes = {
     idInput: PropTypes.string.isRequired,
     selectorType: PropTypes.shape({
         key: PropTypes.string,
-        supportMultiple: PropTypes.bool
+        supportMultiple: PropTypes.bool,
+        pickerConfig: PropTypes.object
     }).isRequired,
     field: FieldPropTypes.isRequired
 };


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17311

## Description

Ensure we have a key for 'Picker in 'data-sel-content-editor-field-type' and also add the picker configuration key (image,file,etc..) in data-sel-content-editor-field-picker-type

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
