### PR TITLE
Revert previous changes for BACKLOG-17314, use a switch language count instead

### DIFF
--- a/src/javascript/ContentEditor/EditPanel/I18nContextHandler.jsx
+++ b/src/javascript/ContentEditor/EditPanel/I18nContextHandler.jsx
@@ -5,7 +5,7 @@ import {useContentEditorConfigContext, useContentEditorContext} from '~/contexts
 export const I18nContextHandler = () => {
     const formik = useFormikContext();
     const contentEditorConfigContext = useContentEditorConfigContext();
-    const {lang, i18nContext} = useContentEditorContext();
+    const {lang, i18nContext, setI18nContext} = useContentEditorContext();
     const formikRef = useRef();
 
     useEffect(() => {
@@ -21,6 +21,16 @@ export const I18nContextHandler = () => {
             }, i18nContext[lang]);
         }
     }, [contentEditorConfigContext.envProps, i18nContext, lang]);
+
+    useEffect(() => {
+        setI18nContext(prev => ({
+            ...prev,
+            memo: {
+                ...prev.memo,
+                count: prev.memo.count + 1
+            }
+        }));
+    }, [lang, setI18nContext]);
 
     return false;
 };

--- a/src/javascript/ContentEditor/EditPanel/I18nContextHandler.jsx
+++ b/src/javascript/ContentEditor/EditPanel/I18nContextHandler.jsx
@@ -27,7 +27,7 @@ export const I18nContextHandler = () => {
             ...prev,
             memo: {
                 ...prev.memo,
-                count: prev.memo.count + 1
+                count: (prev.memo?.count || 0) + 1
             }
         }));
     }, [lang, setI18nContext]);

--- a/src/javascript/SelectorTypes/RichText/RichText.jsx
+++ b/src/javascript/SelectorTypes/RichText/RichText.jsx
@@ -113,7 +113,7 @@ export const RichText = ({field, id, value, onChange, onBlur}) => {
                 onClose={setPicker}
             />}
             <CKEditor
-                key={'v' + (i18nContext.memo?.count || 0)}
+                key={'v' + (i18nContext?.memo?.count || 0)}
                 id={id}
                 data={value}
                 aria-labelledby={`${field.name}-label`}

--- a/src/javascript/SelectorTypes/RichText/RichText.jsx
+++ b/src/javascript/SelectorTypes/RichText/RichText.jsx
@@ -113,7 +113,7 @@ export const RichText = ({field, id, value, onChange, onBlur}) => {
                 onClose={setPicker}
             />}
             <CKEditor
-                key={'v' + i18nContext.memo.count}
+                key={'v' + (i18nContext.memo?.count || 0)}
                 id={id}
                 data={value}
                 aria-labelledby={`${field.name}-label`}

--- a/src/javascript/SelectorTypes/RichText/RichText.jsx
+++ b/src/javascript/SelectorTypes/RichText/RichText.jsx
@@ -1,10 +1,10 @@
-import React, {useContext, useEffect, useState, useRef} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import CKEditor from 'ckeditor4-react';
 import * as PropTypes from 'prop-types';
 import {FieldPropTypes} from '~/ContentEditor.proptypes';
 import {useQuery} from '@apollo/react-hooks';
 import {getCKEditorConfigurationPath} from './CKEditorConfiguration.gql-queries';
-import {ContentEditorContext} from '~/contexts';
+import {ContentEditorContext, useContentEditorContext} from '~/contexts';
 import {PickerDialog} from '~/SelectorTypes/Picker';
 import {useTranslation} from 'react-i18next';
 import {buildPickerContext, fillCKEditorPicker} from './RichText.utils';
@@ -23,18 +23,11 @@ function loadOption(selectorOptions, name) {
 export const RichText = ({field, id, value, onChange, onBlur}) => {
     const {t} = useTranslation('content-editor');
     const [picker, setPicker] = useState(false);
-    const ckeditorRef = useRef();
+    const {i18nContext} = useContentEditorContext();
 
     useEffect(() => {
         CKEditor.editorUrl = window.CKEDITOR_BASEPATH + 'ckeditor.js';
     }, []);
-
-    useEffect(() => {
-        // Force ckeditor to use the value and behave like a normal field
-        if (ckeditorRef.current && ckeditorRef.current.editor && ckeditorRef.current.editor.getData() !== value) {
-            ckeditorRef.current.editor.setData(value);
-        }
-    }, [value]);
 
     const editorContext = useContext(ContentEditorContext);
     const {data, error, loading} = useQuery(
@@ -120,7 +113,7 @@ export const RichText = ({field, id, value, onChange, onBlur}) => {
                 onClose={setPicker}
             />}
             <CKEditor
-                ref={ckeditorRef}
+                key={'v' + i18nContext.memo.count}
                 id={id}
                 data={value}
                 aria-labelledby={`${field.name}-label`}

--- a/src/javascript/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/contexts/ContentEditor/ContentEditor.context.js
@@ -25,7 +25,7 @@ export const ContentEditorContextProvider = ({formQuery, formDataAdapter, childr
         pageComposerCurrentPage: state.pagecomposer.currentPage,
         pageComposerActive: state.pagecomposer.active
     }));
-    const [i18nContext, setI18nContext] = useState({});
+    const [i18nContext, setI18nContext] = useState({memo: {count: 0}});
     const {lang, uilang, site, uuid, contentType, mode, name} = contentEditorConfigContext;
 
     // Get user navigator locale preference

--- a/src/javascript/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/contexts/ContentEditor/ContentEditor.context.js
@@ -25,7 +25,7 @@ export const ContentEditorContextProvider = ({formQuery, formDataAdapter, childr
         pageComposerCurrentPage: state.pagecomposer.currentPage,
         pageComposerActive: state.pagecomposer.active
     }));
-    const [i18nContext, setI18nContext] = useState({memo: {count: 0}});
+    const [i18nContext, setI18nContext] = useState({});
     const {lang, uilang, site, uuid, contentType, mode, name} = contentEditorConfigContext;
 
     // Get user navigator locale preference

--- a/src/javascript/utils/useSwitchLanguage.js
+++ b/src/javascript/utils/useSwitchLanguage.js
@@ -70,7 +70,7 @@ export const useSwitchLanguage = () => {
                 newValues[previousLanguage] = i18nValues;
             }
 
-            if (prev.memo.systemNameLang === undefined && newValues?.shared?.values && Object.keys(newValues.shared.values).includes(Constants.systemName.name)) {
+            if (prev.memo?.systemNameLang === undefined && newValues?.shared?.values && Object.keys(newValues.shared.values).includes(Constants.systemName.name)) {
                 newValues.memo = {
                     ...prev.memo,
                     systemNameLang: previousLanguage

--- a/src/javascript/utils/useSwitchLanguage.js
+++ b/src/javascript/utils/useSwitchLanguage.js
@@ -41,14 +41,6 @@ export const useSwitchLanguage = () => {
         const fields = sections && getFields(sections).filter(field => !field.readOnly);
         const dynamicFieldSets = getDynamicFieldSets(sections);
 
-        const i18nValues = {
-            values: {},
-            validation: {}
-        };
-        const nonI18nValues = {
-            values: {},
-            validation: {}
-        };
         const fieldsObj = fields.reduce((r, f) => Object.assign(r, {[f.name]: f}), {});
         // Add WIP to filtered names as it is not part of any section
         fieldsObj[Constants.wip.fieldName] = {i18n: false};
@@ -60,6 +52,15 @@ export const useSwitchLanguage = () => {
                 ...prev[previousLanguage]?.values
             };
 
+            const i18nValues = {
+                values: {...prev[previousLanguage]?.values},
+                validation: {}
+            };
+            const nonI18nValues = {
+                values: {...prev.shared?.values},
+                validation: {}
+            };
+
             fillValues(formik.values, previousValue, fieldsObj, i18nValues, nonI18nValues, dynamicFieldSets);
             const newValues = Object.keys(nonI18nValues.values).length > 0 ? {shared: nonI18nValues} : {};
 
@@ -69,8 +70,9 @@ export const useSwitchLanguage = () => {
                 newValues[previousLanguage] = i18nValues;
             }
 
-            if (prev?.memo?.systemNameLang === undefined && newValues?.shared?.values && Object.keys(newValues.shared.values).includes(Constants.systemName.name)) {
+            if (prev.memo.systemNameLang === undefined && newValues?.shared?.values && Object.keys(newValues.shared.values).includes(Constants.systemName.name)) {
                 newValues.memo = {
+                    ...prev.memo,
                     systemNameLang: previousLanguage
                 };
             }


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17314
https://jira.jahia.org/browse/BACKLOG-17322

## Description

Revert #1167 as onChange/useEffect cannot work in sync.
Add a "count" update on every language change, after i18n values have been set.
Use new CKEditor when language and values have changed.

Also fix the useSwitchLanguage where unchanged i18n values were lost (BACKLOG-17230)
