### PR TITLE
BACKLOG-17237 - Add picker dialog cypress tests

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog.jsx
@@ -127,6 +127,7 @@ export const PickerDialog = ({
     return (
         <Dialog
             fullScreen
+            data-sel-role="picker-dialog"
             classes={{root: styles.rootDialog}}
             open={isOpen}
             TransitionComponent={Transition}

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog2.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog2.jsx
@@ -167,6 +167,7 @@ export const PickerDialog = ({
     return (
         <Dialog
             fullScreen
+            data-sel-role="picker-dialog"
             classes={{root: styles.rootDialog}}
             open={isOpen}
             TransitionComponent={Transition}

--- a/tests/cypress/e2e/createContent.cy.ts
+++ b/tests/cypress/e2e/createContent.cy.ts
@@ -1,5 +1,5 @@
 import { ContentEditor } from '../page-object'
-import {Button, getComponentByRole} from "@jahia/cypress";
+import { Button, getComponentByRole } from '@jahia/cypress'
 
 describe('Create content tests', { retries: 10 }, () => {
     let contentEditor: ContentEditor

--- a/tests/cypress/e2e/pickers/picker.cy.ts
+++ b/tests/cypress/e2e/pickers/picker.cy.ts
@@ -1,0 +1,121 @@
+import {contentTypes} from "../../fixtures/pickers/contentTypes";
+import {Picker} from "../../page-object/picker";
+import {assertUtils} from "../../utils/assertUtils";
+import {AccordionItem} from "../../page-object/accordionItem";
+import {ContentEditor} from "../../page-object";
+import gql from "graphql-tag";
+
+describe('Picker tests', () => {
+
+    const siteKey = 'digitall'
+    let picker: Picker
+
+    beforeEach(() => {
+        // cy.executeGroovy('createSite.groovy', { SITEKEY: siteKey })
+        cy.login() // edit in chief
+        const pageComposer = ContentEditor.visit(siteKey, 'en', 'home.html').getPageComposer()
+        picker = new Picker(pageComposer)
+        // cy.runProvisioningScript({fileName:'pickers/install-qa-module.yaml',type:'application/yaml'})
+    })
+
+    afterEach(() => {
+        cy.logout()
+        // cy.executeGroovy('deleteSite.groovy', { SITEKEY: siteKey })
+    })
+
+    // tests
+
+    it('should display content reference picker', () => {
+        const pickerDialog = picker.open(contentTypes['contentReference'])
+
+        // assert components are visible
+        assertUtils.isVisible(pickerDialog.get())
+        assertUtils.isVisible(pickerDialog.getSiteSwitcher())
+        assertUtils.isVisible(pickerDialog.getAccordion())
+
+        // assert pages accordion is expanded and populated
+        const pagesAccordion:AccordionItem = pickerDialog.getAccordionItem('picker-pages');
+        assertUtils.isAriaExpanded(pagesAccordion.getHeader())
+        const rootTree = pagesAccordion.getTreeItems().first()
+        rootTree.should('not.be.empty')
+
+        // assert content accordion is visible
+        pickerDialog.getAccordionItem('picker-contents').getHeader()
+            .should('be.visible')
+            .and('have.attr', 'aria-expanded')
+            .and('equal', 'false')
+    })
+
+
+    it('should display file/image reference picker', () => {
+        const pickerDialog = picker.open(contentTypes['fileReference'])
+
+        // assert components are visible
+        assertUtils.isVisible(pickerDialog.get())
+        assertUtils.isVisible(pickerDialog.getSiteSwitcher())
+        assertUtils.isVisible(pickerDialog.getAccordion())
+
+        // assert media accordion is expanded and populated
+        const pagesAccordion:AccordionItem = pickerDialog.getAccordionItem('picker-media');
+        assertUtils.isAriaExpanded(pagesAccordion.getHeader())
+        const rootTree = pagesAccordion.getTreeItems().first()
+        rootTree.should('not.be.empty')
+    })
+
+    it('should go to previous location', () => {
+        let pickerDialog = picker.open(contentTypes['fileReference'])
+        let pagesAccordion:AccordionItem = pickerDialog.getAccordionItem('picker-media');
+        assertUtils.isVisible(pagesAccordion.getHeader())
+
+        cy.log('select files > images > companies')
+        pagesAccordion.expandTreeItem('images')
+        pagesAccordion.getTreeItem('companies').click()
+        pickerDialog.cancel()
+
+        cy.log('re-open file media picker')
+        pickerDialog = picker.open(contentTypes['fileReference'])
+        pagesAccordion = pickerDialog.getAccordionItem('picker-media');
+
+        cy.log('verify files > images > companies still selected')
+        pagesAccordion.getTreeItem('companies').find('div')
+            .should('have.class', 'moonstone-selected')
+    })
+
+    it('should go to root when previous location is not available', () => {
+        const folderName = "testPrevLocation"
+        const parentPath = `/sites/${siteKey}/files/images`
+
+        cy.log(`create folder '${folderName}' in files/images`)
+        cy.apollo({
+            mutationFile: 'pickers/createFolder.graphql',
+            variables: { folderName, parentPath }
+        })
+
+        cy.log('open file picker dialog')
+        let pickerDialog = picker.open(contentTypes['fileReference'])
+        let pagesAccordion: AccordionItem = pickerDialog.getAccordionItem('picker-media');
+        assertUtils.isVisible(pagesAccordion.getHeader())
+
+        cy.log('assert created folder exists and select')
+        pagesAccordion.expandTreeItem('images')
+        pagesAccordion.getTreeItem(folderName).click().should('be.visible')
+        pickerDialog.cancel()
+
+        cy.log(`delete folder '${folderName}'`)
+        cy.apollo({
+            mutationFile: "pickers/deleteFolder.graphql",
+            variables: { pathOrId: `${parentPath}/${folderName}`}
+        })
+
+        // cy.reload() // fixes issue of
+        cy.log('re-open file picker')
+        pickerDialog = picker.open(contentTypes['imageReference'])
+        pagesAccordion = pickerDialog.getAccordionItem('picker-media');
+
+        cy.log(`verify ${folderName} is not selected and root is selected`)
+        pagesAccordion.getTreeItem(folderName).should('not.exist')
+        pagesAccordion.getTreeItem('files').find('div')
+            .should('have.class', 'moonstone-selected')
+    })
+
+})

--- a/tests/cypress/fixtures/pickers/contentTypes.ts
+++ b/tests/cypress/fixtures/pickers/contentTypes.ts
@@ -1,0 +1,32 @@
+
+interface ContentTypes {
+    [key: string]: ContentType
+}
+
+/*
+ *  - typeName: Content type to search for when adding content; case sensitive
+ *  - fieldNodeType: content type field to open picker with; corresponds with 'data-sel-content-editor-field' attr
+ */
+interface ContentType {
+    typeName: string,
+    fieldNodeType: string
+}
+
+
+const contentTypes: ContentTypes = {
+    'contentReference': {
+        typeName: 'Content reference',
+        fieldNodeType: 'jnt:contentReference_j:node',
+
+    },
+    'fileReference': {
+        typeName: 'File reference',
+        fieldNodeType: 'jnt:fileReference_j:node',
+    },
+    'imageReference': {
+        typeName: 'Image (from the Document Manager)',
+        fieldNodeType: 'jnt:imageReferenceLink_j:node',
+    }
+}
+
+export {contentTypes, ContentType};

--- a/tests/cypress/fixtures/pickers/contentTypes.ts
+++ b/tests/cypress/fixtures/pickers/contentTypes.ts
@@ -1,4 +1,3 @@
-
 interface ContentTypes {
     [key: string]: ContentType
 }
@@ -8,25 +7,23 @@ interface ContentTypes {
  *  - fieldNodeType: content type field to open picker with; corresponds with 'data-sel-content-editor-field' attr
  */
 interface ContentType {
-    typeName: string,
+    typeName: string
     fieldNodeType: string
 }
 
-
 const contentTypes: ContentTypes = {
-    'contentReference': {
+    contentReference: {
         typeName: 'Content reference',
         fieldNodeType: 'jnt:contentReference_j:node',
-
     },
-    'fileReference': {
+    fileReference: {
         typeName: 'File reference',
         fieldNodeType: 'jnt:fileReference_j:node',
     },
-    'imageReference': {
+    imageReference: {
         typeName: 'Image (from the Document Manager)',
         fieldNodeType: 'jnt:imageReferenceLink_j:node',
-    }
+    },
 }
 
-export {contentTypes, ContentType};
+export { contentTypes, ContentType }

--- a/tests/cypress/fixtures/pickers/createContent.graphql
+++ b/tests/cypress/fixtures/pickers/createContent.graphql
@@ -1,0 +1,72 @@
+mutation createContent {
+    jcr {
+        content: mutateNode(pathOrId: "/sites/digitall/contents") {
+            addChild(name: "ce-picker-contents", primaryNodeType: "jnt:contentFolder") {
+                addChildrenBatch(
+                    nodes: [
+                        {
+                            name: "test-content1"
+                            primaryNodeType: "jnt:bigText"
+                            properties: [{ name: "text", language: "en", value: "test 1" }]
+                        }
+                        {
+                            name: "test-content2"
+                            primaryNodeType: "jnt:bigText"
+                            properties: [{ name: "text", language: "en", value: "test 2" }]
+                        }
+                        {
+                            name: "test-content3"
+                            primaryNodeType: "jnt:bigText"
+                            properties: [{ name: "text", language: "en", value: "test 3" }]
+                        }
+                        {
+                            name: "content-folder1"
+                            primaryNodeType: "jnt:contentFolder"
+                            children: [
+                                {
+                                    name: "test-content4"
+                                    primaryNodeType: "jnt:bigText"
+                                    properties: [{ name: "text", language: "en", value: "test 4" }]
+                                }
+                                {
+                                    name: "test-content5"
+                                    primaryNodeType: "jnt:bigText"
+                                    properties: [{ name: "text", language: "en", value: "test 5" }]
+                                }
+                            ]
+                        }
+                    ]
+                ) {
+                    uuid
+                }
+            }
+        }
+        fileFolder: addNode(name: "ce-picker-files", parentPathOrId: "/sites/digitall/files", primaryNodeType: "jnt:folder") {
+            uuid
+        }
+        files: copyNodes(nodes: [
+            {
+                pathOrId: "/sites/digitall/files/images/people/user.jpg",
+                destName: "user.jpg",
+                destParentPathOrId: "/sites/digitall/files/ce-picker-files"
+            }
+            {
+                pathOrId: "/sites/digitall/files/images/people/user.jpg",
+                destName: "user2.jpg",
+                destParentPathOrId: "/sites/digitall/files/ce-picker-files"
+            }
+            {
+                pathOrId: "/sites/digitall/files/images/pdf/Digitall Financial Report.pdf",
+                destName: "doc1.pdf",
+                destParentPathOrId: "/sites/digitall/files/ce-picker-files"
+            }
+            {
+                pathOrId: "/sites/digitall/files/images/pdf/Digitall Financial Report.pdf",
+                destName: "doc2.pdf",
+                destParentPathOrId: "/sites/digitall/files/ce-picker-files"
+            }
+        ]) {
+            uuid
+        }
+    }
+}

--- a/tests/cypress/fixtures/pickers/createFolder.graphql
+++ b/tests/cypress/fixtures/pickers/createFolder.graphql
@@ -1,0 +1,13 @@
+mutation CreateFolderMutation($parentPath: String!, $folderName: String!) {
+    jcr {
+        addNode(
+            parentPathOrId: $parentPath
+            name: $folderName
+            primaryNodeType: "jnt:folder"
+        ) {
+            node {
+                uuid
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/pickers/deleteContent.graphql
+++ b/tests/cypress/fixtures/pickers/deleteContent.graphql
@@ -1,0 +1,6 @@
+mutation deleteContent {
+    jcr {
+        content: deleteNode(pathOrId: "/sites/digitall/contents/ce-picker-contents"),
+        file: deleteNode(pathOrId: "/sites/digitall/files/ce-picker-files")
+    }
+}

--- a/tests/cypress/fixtures/pickers/deleteFolder.graphql
+++ b/tests/cypress/fixtures/pickers/deleteFolder.graphql
@@ -1,0 +1,7 @@
+mutation DeleteFolder($pathOrId: String!) {
+    jcr {
+        mutateNode(pathOrId:$pathOrId) {
+            delete
+        }
+    }
+}

--- a/tests/cypress/fixtures/pickers/install-qa-module.yaml
+++ b/tests/cypress/fixtures/pickers/install-qa-module.yaml
@@ -1,0 +1,9 @@
+# Install and start QA-Module to get access to custom picker configurations
+- addMavenRepository: "https://devtools.jahia.com/nexus/content/groups/internal@id=jahia-internal@snapshots"
+  username: ${env:NEXUS_USERNAME}
+  password: ${env:NEXUS_PASSWORD}
+- installBundle:
+    - 'mvn:org.jahia.modules/qa-module/3.1.0-SNAPSHOT'
+  autoStart: true
+  uninstallPreviousVersion: false
+

--- a/tests/cypress/page-object/accordionItem.ts
+++ b/tests/cypress/page-object/accordionItem.ts
@@ -1,23 +1,26 @@
-import {Accordion} from "@jahia/cypress";
+import { Accordion } from '@jahia/cypress'
 
 export class AccordionItem {
-
-    accordion:Accordion
+    accordion: Accordion
     itemName: string
 
     /**
      * @param accordion
      * @param itemName - match accordion header aria-controls attribute value
      */
-    constructor(accordion:Accordion, itemName:string) {
+    constructor(accordion: Accordion, itemName: string) {
         this.accordion = accordion
         accordion.should('exist')
         this.itemName = itemName
     }
 
     getHeader() {
-        return this.accordion.get()
-            .find(`section.moonstone-accordionItem header[aria-controls="${this.itemName}"]`)
+        return this.accordion.get().find(`section.moonstone-accordionItem header[aria-controls="${this.itemName}"]`)
+    }
+
+    click() {
+        this.accordion.click(this.itemName)
+        return this
     }
 
     getSection() {
@@ -39,11 +42,4 @@ export class AccordionItem {
     expandTreeItem(role) {
         return this.getTreeItem(role).find('.moonstone-treeView_itemToggle').click()
     }
-
-
-
-    getRootItem() {
-
-    }
-
 }

--- a/tests/cypress/page-object/accordionItem.ts
+++ b/tests/cypress/page-object/accordionItem.ts
@@ -1,0 +1,49 @@
+import {Accordion} from "@jahia/cypress";
+
+export class AccordionItem {
+
+    accordion:Accordion
+    itemName: string
+
+    /**
+     * @param accordion
+     * @param itemName - match accordion header aria-controls attribute value
+     */
+    constructor(accordion:Accordion, itemName:string) {
+        this.accordion = accordion
+        accordion.should('exist')
+        this.itemName = itemName
+    }
+
+    getHeader() {
+        return this.accordion.get()
+            .find(`section.moonstone-accordionItem header[aria-controls="${this.itemName}"]`)
+    }
+
+    getSection() {
+        return this.getHeader().parent('section')
+    }
+
+    getTree() {
+        return this.getSection().find('[role="tree"]')
+    }
+
+    getTreeItems() {
+        return this.getSection().find('[role="treeitem"]')
+    }
+
+    getTreeItem(role) {
+        return this.getSection().find(`[role="treeitem"][data-sel-role=${role}]`)
+    }
+
+    expandTreeItem(role) {
+        return this.getTreeItem(role).find('.moonstone-treeView_itemToggle').click()
+    }
+
+
+
+    getRootItem() {
+
+    }
+
+}

--- a/tests/cypress/page-object/pageComposer.ts
+++ b/tests/cypress/page-object/pageComposer.ts
@@ -20,6 +20,15 @@ export class PageComposer extends BasePage {
         return this
     }
 
+    createContent(contentType: string) {
+        this
+            .openCreateContent()
+            .getContentTypeSelector()
+            .searchForContentType(contentType)
+            .selectContentType(contentType)
+            .create()
+    }
+
     refresh() {
         cy.iframe('#page-composer-frame', this.iFrameOptions).within(() => {
             cy.get('.window-actions-refresh').click()

--- a/tests/cypress/page-object/pageComposer.ts
+++ b/tests/cypress/page-object/pageComposer.ts
@@ -21,8 +21,7 @@ export class PageComposer extends BasePage {
     }
 
     createContent(contentType: string) {
-        this
-            .openCreateContent()
+        this.openCreateContent()
             .getContentTypeSelector()
             .searchForContentType(contentType)
             .selectContentType(contentType)

--- a/tests/cypress/page-object/picker.ts
+++ b/tests/cypress/page-object/picker.ts
@@ -1,26 +1,28 @@
 import {
     Accordion,
     BaseComponent,
+    Button,
+    Dropdown,
+    getComponent,
     getComponentByAttr,
     getComponentByRole,
-    getComponent,
-    SecondaryNav, Dropdown, Button
-} from "@jahia/cypress";
-import {ContentEditor} from "./contentEditor";
-import {PageComposer} from "./pageComposer";
-import {ContentType} from "../fixtures/pickers/contentTypes";
-import {AccordionItem} from "./accordionItem";
+    SecondaryNav,
+    Table,
+} from '@jahia/cypress'
+import { PageComposer } from './pageComposer'
+import { ContentType } from '../fixtures/pickers/contentTypes'
+import { AccordionItem } from './accordionItem'
 
 export class Picker {
-
     pageComposer: PageComposer
     pickerDialog: BaseComponent
     siteSwitcher: Dropdown
 
     secondaryNav: SecondaryNav
     accordion: Accordion
+    table: Table
 
-    constructor(pageComposer:PageComposer) {
+    constructor(pageComposer: PageComposer) {
         this.pageComposer = pageComposer
     }
 
@@ -30,14 +32,14 @@ export class Picker {
      */
     open(contentType: ContentType) {
         this.pageComposer.createContent(contentType.typeName)
-        let parent = getComponentByAttr(BaseComponent, "data-sel-content-editor-field", contentType.fieldNodeType)
+        const parent = getComponentByAttr(BaseComponent, 'data-sel-content-editor-field', contentType.fieldNodeType)
         parent.get().find('button').click()
-        this.pickerDialog = getComponentByRole(BaseComponent, "picker-dialog")
-        return this;
+        this.pickerDialog = getComponentByRole(BaseComponent, 'picker-dialog')
+        return this
     }
 
     get() {
-        return this.pickerDialog;
+        return this.pickerDialog
     }
 
     getSiteSwitcher() {
@@ -45,7 +47,7 @@ export class Picker {
             this.siteSwitcher = getComponentByAttr(Dropdown, 'data-cm-role', 'site-switcher')
         }
         // make sure dialog is open before returning siteSwitcher
-        return this.pickerDialog && this.siteSwitcher;
+        return this.pickerDialog && this.siteSwitcher
     }
 
     getAccordion(): Accordion {
@@ -59,8 +61,8 @@ export class Picker {
     /**
      * @param itemName -
      */
-    getAccordionItem(itemName:string) {
-        return new AccordionItem(this.getAccordion(), itemName);
+    getAccordionItem(itemName: string) {
+        return new AccordionItem(this.getAccordion(), itemName)
     }
 
     cancel() {
@@ -68,4 +70,18 @@ export class Picker {
         getComponentByRole(Button, 'backButton').click() // cancel create content
     }
 
+    getTable() {
+        if (!this.table) {
+            this.table = getComponent(Table, this.pickerDialog)
+        }
+        return this.table
+    }
+
+    getTableRow(content:string) {
+        return this.getTable().get().find('.moonstone-TableRow').filter(':contains("content-folder1")')
+    }
+
+    getHeaderByName(name: string) {
+        return cy.get('.moonstone-tableHead .moonstone-TableRow').filter(`:contains("${name}")`)
+    }
 }

--- a/tests/cypress/page-object/picker.ts
+++ b/tests/cypress/page-object/picker.ts
@@ -1,0 +1,71 @@
+import {
+    Accordion,
+    BaseComponent,
+    getComponentByAttr,
+    getComponentByRole,
+    getComponent,
+    SecondaryNav, Dropdown, Button
+} from "@jahia/cypress";
+import {ContentEditor} from "./contentEditor";
+import {PageComposer} from "./pageComposer";
+import {ContentType} from "../fixtures/pickers/contentTypes";
+import {AccordionItem} from "./accordionItem";
+
+export class Picker {
+
+    pageComposer: PageComposer
+    pickerDialog: BaseComponent
+    siteSwitcher: Dropdown
+
+    secondaryNav: SecondaryNav
+    accordion: Accordion
+
+    constructor(pageComposer:PageComposer) {
+        this.pageComposer = pageComposer
+    }
+
+    /*
+     * Open picker by adding content type for a selected field
+     * @param contentTypeKey key as defined in fixtures/pickers/contentTypes definition
+     */
+    open(contentType: ContentType) {
+        this.pageComposer.createContent(contentType.typeName)
+        let parent = getComponentByAttr(BaseComponent, "data-sel-content-editor-field", contentType.fieldNodeType)
+        parent.get().find('button').click()
+        this.pickerDialog = getComponentByRole(BaseComponent, "picker-dialog")
+        return this;
+    }
+
+    get() {
+        return this.pickerDialog;
+    }
+
+    getSiteSwitcher() {
+        if (!this.siteSwitcher) {
+            this.siteSwitcher = getComponentByAttr(Dropdown, 'data-cm-role', 'site-switcher')
+        }
+        // make sure dialog is open before returning siteSwitcher
+        return this.pickerDialog && this.siteSwitcher;
+    }
+
+    getAccordion(): Accordion {
+        if (!this.accordion) {
+            const secondaryNav = getComponent(SecondaryNav)
+            this.accordion = getComponent(Accordion, secondaryNav)
+        }
+        return this.accordion
+    }
+
+    /**
+     * @param itemName -
+     */
+    getAccordionItem(itemName:string) {
+        return new AccordionItem(this.getAccordion(), itemName);
+    }
+
+    cancel() {
+        getComponentByAttr(Button, 'data-sel-picker-dialog-action', 'cancel').click() // cancel picker
+        getComponentByRole(Button, 'backButton').click() // cancel create content
+    }
+
+}

--- a/tests/cypress/page-object/tableHeaderRow.ts
+++ b/tests/cypress/page-object/tableHeaderRow.ts
@@ -1,0 +1,5 @@
+import { BaseComponent } from '@jahia/cypress'
+
+export class TableHeaderRow extends BaseComponent {
+    static defaultSelector = '.moonstone-tableHead .moonstone-TableRow'
+}

--- a/tests/cypress/utils/assertUtils.ts
+++ b/tests/cypress/utils/assertUtils.ts
@@ -1,0 +1,15 @@
+
+export const assertUtils = {
+    isAriaExpanded(elem) {
+        return elem.should('have.attr', 'aria-expanded').and('equal', 'true')
+    },
+
+    isAriaCollapsed(elem) {
+        return elem.should('have.attr', 'aria-expanded').and('equal', 'false')
+    },
+
+    isVisible(elem) {
+        return elem.should('be.visible')
+    }
+
+}

--- a/tests/cypress/utils/assertUtils.ts
+++ b/tests/cypress/utils/assertUtils.ts
@@ -1,4 +1,3 @@
-
 export const assertUtils = {
     isAriaExpanded(elem) {
         return elem.should('have.attr', 'aria-expanded').and('equal', 'true')
@@ -10,6 +9,5 @@ export const assertUtils = {
 
     isVisible(elem) {
         return elem.should('be.visible')
-    }
-
+    },
 }

--- a/tests/cypress/utils/index.js
+++ b/tests/cypress/utils/index.js
@@ -1,0 +1,1 @@
+export * from './assertions';

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -6,3 +6,9 @@
   - 'mvn:org.jahia.modules/content-editor'
   autoStart: true
   uninstallPreviousVersion: true
+
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal@id=jahia-internal@snapshots'
+  username: ${env:NEXUS_USERNAME}
+  password: ${env:NEXUS_PASSWORD}
+- installBundle:
+    - 'mvn:org.jahia.modules/qa-module/3.1.0-SNAPSHOT'


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17237

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Few cypress base test cases to cover the picker epic story and to expand on for more detailed scenarios (see covered scenarios in ticket).

Also added a `data-sel-role` for the picker dialog to target in tests.

Currently failing a test until https://jira.jahia.org/browse/BACKLOG-17572 (check for type column in table) and https://jira.jahia.org/browse/BACKLOG-17503 (table missing on content folders) is resolved.