### PR TITLE
BACKLOG-17577: Fixed picker selection

### DIFF
--- a/src/javascript/SelectorTypes/Picker/Picker2.jsx
+++ b/src/javascript/SelectorTypes/Picker/Picker2.jsx
@@ -100,7 +100,6 @@ export const Picker2 = ({field, value, editorContext, inputContext, onChange, on
             <PickerDialog
                 isOpen={isDialogOpen}
                 editorContext={editorContext}
-                inputContext={inputContext}
                 pickerConfig={pickerConfig}
                 initialSelectedItem={fieldData && fieldData.path}
                 accordionItemProps={parsedOptions.accordionItem}

--- a/src/javascript/SelectorTypes/Picker/Picker2.redux.js
+++ b/src/javascript/SelectorTypes/Picker/Picker2.redux.js
@@ -13,6 +13,7 @@ export const {
     cePickerSetPage,
     cePickerSetPageSize,
     cePickerSetSort,
+    cePickerSetSelection,
     cePickerAddSelection,
     cePickerRemoveSelection,
     cePickerSwitchSelection,
@@ -29,6 +30,7 @@ export const {
     'CE_PICKER_SET_PAGE',
     'CE_PICKER_SET_PAGE_SIZE',
     'CE_PICKER_SET_SORT',
+    'CE_PICKER_SET_SELECTION',
     'CE_PICKER_ADD_SELECTION',
     'CE_PICKER_REMOVE_SELECTION',
     'CE_PICKER_SWITCH_SELECTION',
@@ -106,6 +108,10 @@ export const registerPickerReducer = registry => {
         [cePickerSetSort]: (state, action) => ({
             ...state,
             sort: action.payload
+        }),
+        [cePickerSetSelection]: (state, action) => ({
+            ...state,
+            selection: action.payload
         }),
         [cePickerAddSelection]: (state, action) => ({
             ...state,

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog2.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog2.jsx
@@ -25,7 +25,7 @@ import {useNodeInfo} from '@jahia/data-helper';
 import RightPanel from './RightPanel';
 import {ContentNavigation, SiteSwitcher} from '@jahia/jcontent';
 import {encodeJCRPath} from '~/utils';
-import {useLazyQuery, useQuery} from '@apollo/react-hooks';
+import {useLazyQuery} from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 import {useContentEditorConfigContext} from '~/contexts';
 

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
@@ -39,10 +39,8 @@ export const allowDoubleClickNavigation = (nodeType, fcn) => {
 
 const selector = state => ({
     mode: state.contenteditor.picker.mode.replace('picker-', ''),
-    siteKey: state.contenteditor.picker.site,
     path: state.contenteditor.picker.path,
     pagination: state.contenteditor.picker.pagination,
-    selection: state.contenteditor.picker.selection,
     tableView: state.contenteditor.picker.tableView
 });
 

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -31,7 +31,7 @@ const RightPanel = ({pickerConfig, onClose, onItemSelection}) => {
     const selectElement = () => {
         if (selection) {
             // Todo: BACKLOG-12581 - Multiple is not supported yet in pickers. Always return a single value.
-            onItemSelection(Array.isArray(selection) ? selection[0] : selection);
+            onItemSelection(selection[0]);
         } else {
             onClose();
         }

--- a/src/javascript/SelectorTypes/RichText/RichText.jsx
+++ b/src/javascript/SelectorTypes/RichText/RichText.jsx
@@ -111,7 +111,7 @@ export const RichText = ({field, id, value, onChange, onBlur}) => {
                 field={field}
                 pickerConfig={pickerConfig}
                 onItemSelection={handleItemSelection}
-                onClose={setPicker}
+                onClose={() => setPicker(false)}
             />}
             <CKEditor
                 key={'v' + (i18nContext?.memo?.count || 0)}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17577

## Description

Remove duplicate selection state, do not use inputContext in dialog (unusable from a richtext). Use initialSelectedItem for initial state, as a path or path array.
Fixed onClose in RichText
