### PR TITLE
BACKLOG-19873: Display only direct children of pages in structured view

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
@@ -87,9 +87,25 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
         query: layoutQuery,
         variables: (isStructuredView && tableView.viewType !== Constants.tableView.type.CONTENT) ?
             queryHandler.updateQueryParamsForStructuredView(layoutQueryParams, preloadForTableViewType, mode) :
-            queryHandler.getQueryParams({path, uilang, lang, params, pagination: {...pagination, currentPage: 0}, sort, viewType: preloadForTableViewType}),
+            queryHandler.getQueryParams({
+                path, uilang, lang, params, pagination: {...pagination, currentPage: 0}, sort, viewType: preloadForTableViewType
+            }),
         fetchPolicy: fetchPolicy
-    }), [isStructuredView, lang, layoutQuery, layoutQueryParams, mode, pagination, path, preloadForTableViewType, queryHandler, sort, uilang, params]);
+    }), [
+        isStructuredView,
+        tableView.viewType,
+        lang,
+        layoutQuery,
+        layoutQueryParams,
+        mode,
+        pagination,
+        path,
+        preloadForTableViewType,
+        queryHandler,
+        sort,
+        uilang,
+        params
+    ]);
 
     // Preload data either for pages or contents depending on current view type
     const preloadedData = usePreloadedData({

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
@@ -69,7 +69,7 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
         () => {
             let r = queryHandler.getQueryParams({path, uilang, lang, params, pagination, sort, viewType: tableView.viewType});
             // Update params for structured view to use different type and recursion filters
-            if (isStructuredView) {
+            if (isStructuredView && tableView.viewType === Constants.tableView.type.CONTENT) {
                 r = queryHandler.updateQueryParamsForStructuredView(r, tableView.viewType, mode);
             }
 
@@ -85,7 +85,7 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
 
     const options = useMemo(() => ({
         query: layoutQuery,
-        variables: isStructuredView ?
+        variables: (isStructuredView && tableView.viewType !== Constants.tableView.type.CONTENT) ?
             queryHandler.updateQueryParamsForStructuredView(layoutQueryParams, preloadForTableViewType, mode) :
             queryHandler.getQueryParams({path, uilang, lang, params, pagination: {...pagination, currentPage: 0}, sort, viewType: preloadForTableViewType}),
         fetchPolicy: fetchPolicy


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19873

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Display only direct children when pages tab is in structured view

* use list query to list direct children only if it's structured view and is not displaying content (i.e. use structured view query only for content)