### PR TITLE
BACKLOG-17350: Add UI components for multiple selection

### DIFF
--- a/src/javascript/SelectorTypes/Picker/Picker2.redux.js
+++ b/src/javascript/SelectorTypes/Picker/Picker2.redux.js
@@ -1,6 +1,7 @@
 import {createActions, handleActions} from 'redux-actions';
 import {COMBINED_REDUCERS_NAME} from '~/registerReducer';
 import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
+import {toArray} from './Picker2.utils';
 
 export const {
     cePickerSite,
@@ -37,8 +38,6 @@ export const {
     'CE_PICKER_CLEAR_SELECTION',
     'CE_PICKER_SET_TABLE_VIEW_MODE',
     'CE_PICKER_SET_TABLE_VIEW_TYPE');
-
-const toArray = value => (Array.isArray(value) ? value : [value]);
 
 export const registerPickerReducer = registry => {
     const initialState = {

--- a/src/javascript/SelectorTypes/Picker/Picker2.scss
+++ b/src/javascript/SelectorTypes/Picker/Picker2.scss
@@ -1,0 +1,11 @@
+.fieldComponentContainer {
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--spacing-nano);
+}
+
+.addButton {
+    margin: var(--spacing-small) 0;
+
+    text-transform: uppercase;
+}

--- a/src/javascript/SelectorTypes/Picker/Picker2.utils.js
+++ b/src/javascript/SelectorTypes/Picker/Picker2.utils.js
@@ -88,3 +88,5 @@ export const arrayValue = value => {
 };
 
 export const booleanValue = v => typeof v === 'string' ? v === 'true' : Boolean(v);
+
+export const toArray = value => (Array.isArray(value) ? value : [value]);

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -31,7 +31,7 @@ const RightPanel = ({pickerConfig, onClose, onItemSelection}) => {
     const selectElement = () => {
         if (selection) {
             // Todo: BACKLOG-12581 - Multiple is not supported yet in pickers. Always return a single value.
-            onItemSelection(selection[0]);
+            onItemSelection(selection);
         } else {
             onClose();
         }

--- a/src/javascript/SelectorTypes/Picker/registerPicker.js
+++ b/src/javascript/SelectorTypes/Picker/registerPicker.js
@@ -20,7 +20,7 @@ export const getPickerSelectorType = (registry, options) => {
 
     return ({
         cmp: Picker2,
-        supportsMultiple: false,
+        supportMultiple: false,
         key: 'Picker',
         pickerConfig
     });


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17350

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add UI components for multiple selection in content editor and enable handling of multiple selection values 

It's stable and working but temporarily disabled for now as selection in picker dialog still only allows single selection but I still want to merge early to avoid conflicts.