### PR TITLE
BACKLOG-19874: Use default picker if no type is specified (3 accordions)

### DIFF
--- a/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
+++ b/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
@@ -8,9 +8,9 @@ const defaultEditorialListType = ['jmix:editorialContent', 'jnt:page', 'jmix:nav
 export const registerPickerConfig = ceRegistry => {
     ceRegistry.add(Constants.pickerConfig, 'default', mergeDeep({}, ContentPickerConfig, {
         searchSelectorType: 'jmix:searchable',
-        listTypesTable: defaultEditorialListType,
+        listTypesTable: [...defaultEditorialListType, 'jnt:file'],
         selectableTypesTable: ['jnt:content', 'jnt:file', 'jnt:page', 'jmix:navMenuItem'],
-        showOnlyNodesWithTemplates: true
+        showOnlyNodesWithTemplates: false
     }));
 
     ceRegistry.add(Constants.pickerConfig, 'editoriallink', mergeDeep({}, ContentPickerConfig, {

--- a/src/javascript/SelectorTypes/Picker/registerPicker.js
+++ b/src/javascript/SelectorTypes/Picker/registerPicker.js
@@ -6,7 +6,7 @@ import {registerPickerReducer} from '~/SelectorTypes/Picker/Picker2.redux';
 
 export const getPickerSelectorType = (registry, options) => {
     const option = options && options.find(option => option.name === 'type');
-    const pickerConfigKey = option?.value || 'editorial';
+    const pickerConfigKey = option?.value || 'default';
 
     let pickerConfig = registry.get('pickerConfiguration', pickerConfigKey);
 

--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.spec.jsx
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.spec.jsx
@@ -34,10 +34,10 @@ describe('Field container component', () => {
         expect(cmp.props().selectorType.key).toBe('RichText');
     });
 
-    it('should render a ContentPicker component when field type is "picker"', () => {
+    it('should render a default ContentPicker component when field type is "picker" with no option', () => {
         defaultProps.field.selectorType = 'Picker';
         const cmp = shallow(<FieldContainer {...defaultProps}/>).find('Field');
-        expect(cmp.props().selectorType.pickerConfig.key).toBe('editorial');
+        expect(cmp.props().selectorType.pickerConfig.key).toBe('default');
     });
 
     it('should render a MediaPicker component when field type is "picker" and option type is "image"', () => {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19874

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
