### PR TITLE
BACKLOG-19906: modify queryhandlers for pickers

### DIFF
--- a/src/javascript/SelectorTypes/Picker/Picker2.constants.js
+++ b/src/javascript/SelectorTypes/Picker/Picker2.constants.js
@@ -20,7 +20,7 @@ export const Constants = {
     },
     mode: {
         MEDIA: 'picker-media',
-        SEARCH: 'search'
+        SEARCH: 'picker-search'
     }
 };
 

--- a/src/javascript/SelectorTypes/Picker/Picker2.jsx
+++ b/src/javascript/SelectorTypes/Picker/Picker2.jsx
@@ -8,7 +8,7 @@ import {PickerDialog} from './PickerDialog/PickerDialog2';
 import {DisplayAction} from '@jahia/ui-extender';
 import {getButtonRenderer} from '~/utils';
 import {LoaderOverlay} from '~/DesignSystem/LoaderOverlay';
-import {cePickerClearSelection, cePickerSetSearchTerm} from '~/SelectorTypes/Picker/Picker2.redux';
+import {cePickerClearSelection, cePickerKey, cePickerSetSearchTerm} from '~/SelectorTypes/Picker/Picker2.redux';
 import {useDispatch} from 'react-redux';
 import styles from './Picker2.scss';
 import {Button, Close} from '@jahia/moonstone';
@@ -88,6 +88,8 @@ export const Picker2 = ({field, value, editorContext, inputContext, onChange, on
                 cePickerClearSelection(),
                 cePickerSetSearchTerm('')
             ]));
+        } else {
+            dispatch(cePickerKey(pickerConfig.key));
         }
 
         setDialogOpen(open);

--- a/src/javascript/SelectorTypes/Picker/Picker2.redux.js
+++ b/src/javascript/SelectorTypes/Picker/Picker2.redux.js
@@ -4,6 +4,7 @@ import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
 import {toArray} from './Picker2.utils';
 
 export const {
+    cePickerKey,
     cePickerSite,
     cePickerContextSite,
     cePickerMode,
@@ -22,7 +23,8 @@ export const {
     cePickerSetTableViewMode,
     cePickerSetTableViewType,
     cePickerSetSearchTerm,
-    cePickerSetSearchContext} = createActions(
+    cePickerSetSearchPath} = createActions(
+    'CE_PICKER_KEY',
     'CE_PICKER_SITE',
     'CE_PICKER_CONTEXT_SITE',
     'CE_PICKER_MODE',
@@ -41,11 +43,12 @@ export const {
     'CE_PICKER_SET_TABLE_VIEW_MODE',
     'CE_PICKER_SET_TABLE_VIEW_TYPE',
     'CE_PICKER_SET_SEARCH_TERM',
-    'CE_PICKER_SET_SEARCH_CONTEXT');
+    'CE_PICKER_SET_SEARCH_PATH');
 
 export const registerPickerReducer = registry => {
     const initialState = {
         openPaths: [],
+        pickerKey: '',
         mode: 'picker-pages',
         preSearchModeMemo: 'picker-pages',
         site: 'systemsite',
@@ -61,11 +64,15 @@ export const registerPickerReducer = registry => {
             viewMode: Constants.tableView.mode.LIST,
             viewType: Constants.tableView.type.CONTENT
         },
-        searchTerm: '',
-        searchContext: ''
+        searchTerms: '',
+        searchPath: ''
     };
 
     const picker = handleActions({
+        [cePickerKey]: (state, action) => ({
+            ...state,
+            pickerKey: action.payload
+        }),
         [cePickerSite]: (state, action) => ({
             ...state,
             site: action.payload
@@ -97,8 +104,8 @@ export const registerPickerReducer = registry => {
         [cePickerPath]: (state, action) => ({
             ...state,
             path: action.payload,
-            searchContext: (state.searchContext === '' || state.searchContext.indexOf('/') >= 0) ? action.payload : state.searchContext,
-            searchTerm: '',
+            searchPath: (state.searchPath === '' || state.searchPath.indexOf('/') >= 0) ? action.payload : state.searchPath,
+            searchTerms: '',
             pagination: {
                 ...state.pagination,
                 currentPage: 0
@@ -158,12 +165,12 @@ export const registerPickerReducer = registry => {
         }),
         [cePickerSetSearchTerm]: (state, action) => ({
             ...state,
-            searchTerm: action.payload,
+            searchTerms: action.payload,
             mode: action.payload === '' ? state.preSearchModeMemo : Constants.mode.SEARCH
         }),
-        [cePickerSetSearchContext]: (state, action) => ({
+        [cePickerSetSearchPath]: (state, action) => ({
             ...state,
-            searchContext: action.payload
+            searchPath: action.payload
         })
     }, initialState);
 

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.utils.js
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.utils.js
@@ -1,5 +1,3 @@
-import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
-
 export const structureData = function (parentPath, dataForParentPath = []) {
     const structuredData = dataForParentPath.filter(d => d.parent.path === parentPath);
     setSubrows(structuredData, dataForParentPath);
@@ -21,28 +19,4 @@ export const structureData = function (parentPath, dataForParentPath = []) {
             setSubrows(data[i].subRows, rest);
         }
     }
-};
-
-export const resolveQueryConstraints = (pickerConfig, mode, tableViewType, searchTerm, path, searchContext) => {
-    const obj = {
-        selectableTypesTable: pickerConfig.selectableTypesTable,
-        typeFilter: pickerConfig.selectableTypesTable,
-        searchTerms: searchTerm,
-        searchPath: searchTerm ? searchContext : path
-    };
-
-    // Note that when in 'content-folders' there is no pages tab at all as per design of content table in jcontent
-    if (mode === 'picker-pages') {
-        obj.typeFilter = tableViewType === Constants.tableView.type.PAGES ? ['jnt:page'] : pickerConfig.selectableTypesTable.filter(t => t !== 'jnt:page');
-    } else if (mode === 'picker-content-folders') {
-        obj.typeFilter = Array.from(new Set([...pickerConfig.selectableTypesTable, 'jnt:contentFolder']));
-    } else if (mode === 'picker-media') {
-        obj.typeFilter = Array.from(new Set([...pickerConfig.selectableTypesTable, 'jnt:folder']));
-    }
-
-    if (searchTerm !== '') {
-        obj.nodeType = pickerConfig.searchSelectorType;
-    }
-
-    return obj;
 };

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
@@ -55,7 +55,6 @@ const clickHandler = {
         } else if (e.nativeEvent.detail === 2) {
             clearTimeout(this.timeout);
             this.timeout = undefined;
-            fcn();
         }
     }
 };
@@ -179,7 +178,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
                                           className={!selectionProps.checked && className}
                                           isHighlighted={selectionProps.checked}
                                           onClick={e => handleOnClick(e, row)}
-                                          onDoubleClick={e => allowDoubleClickNavigation(node.primaryNodeType.name) && clickHandler.handleEvent(e, () => doubleClickNavigation(node))}
+                                          onDoubleClick={() => allowDoubleClickNavigation(node.primaryNodeType.name) && doubleClickNavigation(node)}
                                 >
                                     {row.cells.map(cell => <React.Fragment key={cell.column.id}>{cell.render('Cell')}</React.Fragment>)}
                                 </TableRow>

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -18,8 +18,8 @@ const RightPanel = ({pickerConfig, onClose, onItemSelection}) => {
     const {selection, mode} = useSelector(state => ({
         selection: state.contenteditor.picker.selection,
         mode: state.contenteditor.picker.mode,
-        searchTerm: state.contenteditor.picker.searchTerm,
-        searchContext: state.contenteditor.picker.searchContext,
+        searchTerm: state.contenteditor.picker.searchTerms,
+        searchPath: state.contenteditor.picker.searchPath,
         currentPath: state.contenteditor.picker.path,
         currentSite: state.contenteditor.picker.site
     }), shallowEqual);

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/Search.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/Search.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Dropdown, SearchContextInput, SiteWeb} from '@jahia/moonstone';
 import styles from './Search.scss';
-import {cePickerSetSearchContext, cePickerSetSearchTerm} from '~/SelectorTypes/Picker/Picker2.redux';
+import {cePickerSetSearchPath, cePickerSetSearchTerm} from '~/SelectorTypes/Picker/Picker2.redux';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import {useTranslation} from 'react-i18next';
 import {registry} from '@jahia/ui-extender';
@@ -14,10 +14,10 @@ import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
 export const Search = () => {
     const {t} = useTranslation('content-editor');
     const dispatch = useDispatch();
-    const {searchTerm, searchContext, preSearchModeMemo, currentPath, currentSite, language, uilang, mode} = useSelector(state => ({
+    const {searchTerms, searchPath, preSearchModeMemo, currentPath, currentSite, language, uilang, mode} = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
-        searchTerm: state.contenteditor.picker.searchTerm,
-        searchContext: state.contenteditor.picker.searchContext,
+        searchTerms: state.contenteditor.picker.searchTerms,
+        searchPath: state.contenteditor.picker.searchPath,
         preSearchModeMemo: state.contenteditor.picker.preSearchModeMemo,
         currentPath: state.contenteditor.picker.path,
         currentSite: state.contenteditor.picker.site,
@@ -34,8 +34,7 @@ export const Search = () => {
     const node = data && data.jcr.nodesByPath[0];
 
     const handleChangeContext = (e, item) => {
-        console.log('Updating search context', item.value);
-        dispatch(cePickerSetSearchContext(item.value));
+        dispatch(cePickerSetSearchPath(item.searchPath));
     };
 
     const previousMode = mode === Constants.mode.SEARCH ? preSearchModeMemo : mode;
@@ -51,7 +50,7 @@ export const Search = () => {
     const handleClearTerms = () => {
         dispatch(batchActions([
             cePickerSetSearchTerm(''),
-            cePickerSetSearchContext(currentPath)
+            cePickerSetSearchPath(currentPath)
         ]));
     };
 
@@ -61,42 +60,40 @@ export const Search = () => {
         [
             {
                 label: t('content-editor:label.contentEditor.picker.rightPanel.searchContextOptions.search'),
-                value: '',
+                searchPath: '',
                 isDisabled: true
             },
             {
                 label: currentSite.substring(0, 1).toUpperCase() + currentSite.substring(1),
-                value: `/sites/${currentSite}`,
+                searchPath: `/sites/${currentSite}`,
                 iconStart: <SiteWeb/>
             },
             {
                 label: t(accordion.label),
-                value: accordion.defaultPath(currentSite),
+                searchPath: accordion.defaultPath(currentSite),
                 iconStart: accordion.icon
             },
             ...(accordion && accordion.getSearchContextData ? accordion.getSearchContextData(currentSite, node, t) : []),
             {
                 label: node?.displayName,
-                value: currentPath,
+                searchPath: currentPath,
                 iconStart: <NodeIcon node={node}/>
             }
         ]
-    ).filter((currentItem, index, array) => array.findIndex(item => item.value === currentItem.value) === index)
-        .filter(value => currentPath.startsWith(value.value));
+    ).filter((currentItem, index, array) => array.findIndex(item => item.searchPath === currentItem.searchPath) === index)
+        .filter(value => currentPath.startsWith(value.searchPath));
 
-    const getCurrentSearchContext = () => {
-        return searchContextData.find(value => value.value === (searchContext === '' ? currentPath : searchContext));
-    };
+    const currentSearchContext = searchContextData.find(value => value.searchPath === (searchPath === '' ? currentPath : searchPath));
 
     return (
         <SearchContextInput
             searchContext={<Dropdown data={searchContextData}
-                                     value={getCurrentSearchContext().value}
-                                     label={getCurrentSearchContext().label}
-                                     icon={getCurrentSearchContext().iconStart}
+                                     value={currentSearchContext.searchPath}
+                                     label={currentSearchContext.label}
+                                     icon={currentSearchContext.iconStart}
                                      onChange={handleChangeContext}/>}
             size="big"
-            value={searchTerm}
+            value={searchTerms}
             className={styles.searchInput}
             onChange={e => handleChangeTerms(e)}
             onClear={e => handleClearTerms(e)}

--- a/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
+++ b/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
@@ -3,32 +3,26 @@ import {ContentPickerConfig} from '~/SelectorTypes/Picker/configs/ContentPickerC
 import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
 import {mergeDeep} from '~/SelectorTypes/Picker/Picker2.utils';
 
-const defaultEditorialListType = ['jmix:editorialContent', 'jnt:page', 'jmix:navMenuItem', 'jnt:contentList', 'jnt:contentFolder', 'nt:folder', 'jmix:siteContent'];
-
 export const registerPickerConfig = ceRegistry => {
     ceRegistry.add(Constants.pickerConfig, 'default', mergeDeep({}, ContentPickerConfig, {
         searchSelectorType: 'jmix:searchable',
-        listTypesTable: [...defaultEditorialListType, 'jnt:file'],
         selectableTypesTable: ['jnt:content', 'jnt:file', 'jnt:page', 'jmix:navMenuItem'],
         showOnlyNodesWithTemplates: false
     }));
 
     ceRegistry.add(Constants.pickerConfig, 'editoriallink', mergeDeep({}, ContentPickerConfig, {
         searchSelectorType: 'jmix:searchable',
-        listTypesTable: defaultEditorialListType,
         selectableTypesTable: ['jnt:page', 'jmix:mainResource'],
         showOnlyNodesWithTemplates: true
     }));
 
     ceRegistry.add(Constants.pickerConfig, 'editorial', mergeDeep({}, ContentPickerConfig, {
         searchSelectorType: 'jmix:searchable',
-        listTypesTable: defaultEditorialListType,
         selectableTypesTable: ['jnt:page', 'jnt:contentList', 'jnt:contentFolder', 'jmix:siteContent', 'jmix:editorialContent']
     }));
 
     ceRegistry.add(Constants.pickerConfig, 'image', mergeDeep({}, MediaPickerConfig, {
         searchSelectorType: 'jmix:image',
-        listTypesTable: ['jmix:image'],
         selectableTypesTable: ['jmix:image']
     }));
 
@@ -41,7 +35,6 @@ export const registerPickerConfig = ceRegistry => {
             searchPlaceholder: 'content-editor:label.contentEditor.edit.fields.contentPicker.searchFilePlaceholder'
         },
         searchSelectorType: 'jnt:folder',
-        listTypesTable: ['jnt:folder'],
         selectableTypesTable: ['jnt:folder']
     }));
 
@@ -50,13 +43,11 @@ export const registerPickerConfig = ceRegistry => {
             dialogTitle: 'content-editor:label.contentEditor.edit.fields.contentPicker.modalFolderTitle'
         },
         searchSelectorType: 'jnt:contentFolder',
-        listTypesTable: ['jnt:contentFolder'],
         selectableTypesTable: ['jnt:contentFolder']
     }));
 
     ceRegistry.add(Constants.pickerConfig, 'page', mergeDeep({}, ContentPickerConfig, {
         searchSelectorType: 'jnt:page',
-        listTypesTable: ['jnt:page'],
         selectableTypesTable: ['jnt:page']
     }));
 
@@ -69,13 +60,11 @@ export const registerPickerConfig = ceRegistry => {
             searchPlaceholder: 'content-editor:label.contentEditor.edit.fields.contentPicker.searchFilePlaceholder'
         },
         searchSelectorType: 'jnt:file',
-        listTypesTable: ['jnt:file'],
         selectableTypesTable: ['jnt:file']
     }));
 
     ceRegistry.add(Constants.pickerConfig, 'category', mergeDeep({}, ContentPickerConfig, {
         searchSelectorType: 'jnt:category',
-        listTypesTable: ['jnt:category'],
         selectableTypesTable: ['jnt:category']
     }));
 

--- a/src/javascript/SelectorTypes/Picker/configs/configPropType.js
+++ b/src/javascript/SelectorTypes/Picker/configs/configPropType.js
@@ -14,7 +14,6 @@ export const configPropType = PropTypes.shape({
         itemSelectionAdapter: PropTypes.func,
         displayTree: PropTypes.bool
     }).isRequired,
-    listTypesTable: PropTypes.arrayOf(PropTypes.string),
     selectableTypesTable: PropTypes.arrayOf(PropTypes.string),
     showOnlyNodesWithTemplates: PropTypes.bool,
     searchSelectorType: PropTypes.string


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19906

## Description

Use modified mode for search, with an additional fieldFilter to only display selectable items.
Modify queryhandlers for pickers instead of adding properties when calling useLayoutQuery. This allows CotnentTypeSelector to get the correct variables values without changing the useLayoutQuery call. Also add the additional isSelectable fragment into queryHandlers.
Move search parameters in params so that they can be handled by getQueryParams()
Minor fix on double-click
Removed unused listTypesTable
