### PR TITLE
BACKLOG-17350: Fix error loop when setting picker modes state

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -18,6 +18,7 @@ const RightPanel = ({pickerConfig, onClose, onItemSelection}) => {
     const {selection, mode} = useSelector(state => ({
         selection: state.contenteditor.picker.selection,
         mode: state.contenteditor.picker.mode,
+        modes: state.contenteditor.picker.modes,
         searchTerm: state.contenteditor.picker.searchTerms,
         searchPath: state.contenteditor.picker.searchPath,
         currentPath: state.contenteditor.picker.path,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17350

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Real fix is actually here https://github.com/Jahia/content-editor/pull/1238/commits/3cc7445e7bdc5683b81b9aedc244d04f6a119583
