### PR TITLE
BACKLOG-17350: Enable multi-selection only for selectable types; Fix error loop

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
@@ -76,10 +76,13 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
     const isStructuredView = Constants.tableView.mode.STRUCTURED === tableView.viewMode;
     const columns = useMemo(() => {
         return allColumnData
-            .filter(c => Constants.mode.MEDIA !== mode || c.id !== 'type') // Do not include type column if media mode
-            .filter(c => field.multiple || c.id !== SELECTION_COLUMN_ID) // Do not include selection if multiple selection is not enabled
-            .filter(c => !pickerConfig?.pickerTable?.columns || [...pickerConfig.pickerTable.columns, SELECTION_COLUMN_ID].includes(c.id)); // Check if picker config specifies which columns to include
-    }, [mode, field.multiple, pickerConfig]);
+            // Do not include type column if media mode
+            .filter(c => Constants.mode.MEDIA !== mode || c.id !== 'type')
+            // Do not include selection if multiple selection is not enabled or if there are no selectable types
+            .filter(c => (field.multiple && rows.some(r => r.isSelectable)) || c.id !== SELECTION_COLUMN_ID)
+            // Check if picker config specifies which columns to include
+            .filter(c => !pickerConfig?.pickerTable?.columns || [...pickerConfig.pickerTable.columns, SELECTION_COLUMN_ID].includes(c.id));
+    }, [mode, field.multiple, pickerConfig, rows]);
     const {
         getTableProps,
         getTableBodyProps,

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -17,19 +17,13 @@ const ButtonRenderer = getButtonRenderer({defaultButtonProps: {variant: 'ghost'}
 const RightPanel = ({pickerConfig, onClose, onItemSelection}) => {
     const {selection, mode} = useSelector(state => ({
         selection: state.contenteditor.picker.selection,
-        mode: state.contenteditor.picker.mode,
-        modes: state.contenteditor.picker.modes,
-        searchTerm: state.contenteditor.picker.searchTerms,
-        searchPath: state.contenteditor.picker.searchPath,
-        currentPath: state.contenteditor.picker.path,
-        currentSite: state.contenteditor.picker.site
+        mode: state.contenteditor.picker.mode
     }), shallowEqual);
     const selectionExpanded = useState(false);
     const {t} = useTranslation('content-editor');
 
     const selectElement = () => {
         if (selection) {
-            // Todo: BACKLOG-12581 - Multiple is not supported yet in pickers. Always return a single value.
             onItemSelection(selection);
         } else {
             onClose();

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
@@ -30,6 +30,7 @@ function getSite(selectedItem) {
 export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConfig, children}) => {
     const state = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
+        modes: state.contenteditor.picker.modes,
         path: state.contenteditor.picker.path,
         openPaths: state.contenteditor.picker.openPaths,
         site: state.contenteditor.picker.site,

--- a/src/javascript/SelectorTypes/Picker/reactTable/plugins/useRowMultipleSelection.jsx
+++ b/src/javascript/SelectorTypes/Picker/reactTable/plugins/useRowMultipleSelection.jsx
@@ -56,12 +56,13 @@ function useInstance(instance) {
     const selection = useSelector(state => state.contenteditor.picker.selection);
     const dispatch = useDispatch();
 
-    const flattenRows = flattenTree(rows).map(r => r.original);
+    const selectableRows = flattenTree(rows).map(r => r.original).filter(r => r.isSelectable);
+    const rowsSet = new Set(selectableRows.map(r => r.uuid));
+    const anySelected = selection.length > 0 && selection.some(r => rowsSet.has(r.uuid));
     const selIdSet = new Set(selection.map(r => r.uuid));
-    const anySelected = selection.length > 0;
     const allSelected = anySelected &&
-        selection.length >= flattenRows.length &&
-        flattenRows.every(r => selIdSet.has(r.uuid)); // Check if all rows are in selection set
+        selection.length >= selectableRows.length &&
+        selectableRows.every(r => selIdSet.has(r.uuid)); // Check if all rows are in selection set
 
     const toggleRowSelected = row => {
         if (row.original.isSelectable) {
@@ -71,9 +72,9 @@ function useInstance(instance) {
 
     const toggleAllRowsSelected = () => {
         if (allSelected) {
-            dispatch(cePickerRemoveSelection(flattenRows));
+            dispatch(cePickerRemoveSelection(selectableRows));
         } else {
-            dispatch(cePickerAddSelection(flattenRows.filter(r => r.isSelectable)));
+            dispatch(cePickerAddSelection(selectableRows));
         }
     };
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17350

* Include selection column only if there is at least one selectable type. 
* Fix selection state for `anySelected`
* Minor cleanup
* Actually fix error loop this time :(