### PR TITLE
BACKLOG-19909 Add picker config to avoid using jcontent's path

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
@@ -119,7 +119,7 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
             // Mode has changed, select path
             if (getSite(newState.path) === newState.site && getAccordionMode(newState.path, pickerConfig) === newState.mode && currentFolderInfo.node) {
                 // 2 - Previously selected path is valid
-            } else if (getSite(state.jcontentPath) === newState.site && getAccordionMode(state.jcontentPath, pickerConfig) === newState.mode) {
+            } else if (getSite(state.jcontentPath) === newState.site && getAccordionMode(state.jcontentPath, pickerConfig) === newState.mode && !pickerConfig.doNotUseJcontentPath) {
                 // 3 - Jcontent path is also valid here, use it
                 newState.path = state.jcontentPath;
             } else {

--- a/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
+++ b/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
@@ -79,6 +79,7 @@ export const registerPickerConfig = ceRegistry => {
         searchSelectorType: 'jnt:virtualsite',
         selectableTypesTable: ['jnt:virtualsite'],
         accordionMode: `picker-${Constants.ACCORDION_ITEM_TYPES.SITE}`,
+        doNotUseJcontentPath: true,
         pickerTable: {
             columns: ['name']
         },


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19909

## Description

Add picker config to avoid using jcontent's path