### PR TITLE
BACKLOG-19909 Some fixes

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
@@ -88,7 +88,7 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
                 } else {
                     newState.path = getPathWithoutFile(selectedNode.path);
                 }
-            } else if (previousState.current.contextSite !== newState.contextSite) {
+            } else if (previousState.current.contextSite !== newState.contextSite || newState.site !== newState.contextSite) {
                 // If context site has changed, reset to the current site (otherwise keep current site)
                 newState.site = pickerConfig.targetSite ? pickerConfig.targetSite : newState.contextSite;
             }
@@ -118,7 +118,8 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
         if (somethingChanged || newState.mode !== previousState.current.mode) {
             // Mode has changed, select path
             if (getSite(newState.path) === newState.site && getAccordionMode(newState.path, pickerConfig) === newState.mode && currentFolderInfo.node) {
-                // 2 - Previously selected path is valid
+                // 2 - Update path for new mode
+                newState.path = accordionItems.find(item => item.key === newState.mode).defaultPath(newState.site);
             } else if (getSite(state.jcontentPath) === newState.site && getAccordionMode(state.jcontentPath, pickerConfig) === newState.mode && !pickerConfig.doNotUseJcontentPath) {
                 // 3 - Jcontent path is also valid here, use it
                 newState.path = state.jcontentPath;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19909

## Description
A couple of fixes for two issues (when in jcontent):

1) 
    Have site picker with systemsite selected and editiorial with no selection
    Open site picker then editorial picker (editorial picker list is empty as the site is switched to systemsite)
2) 
    Have site picker and editorial picker empty
    Open editorial picker then site picker (site picker is empty because it used editorial picker's path to get sites)

