### PR TITLE
BACKLOG-17381: Adapt queryHandlers, add page/folder/contentfolder modes

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
@@ -5,7 +5,6 @@ import {Loader} from '@jahia/moonstone';
 import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
 import {configPropType} from '~/SelectorTypes/Picker/configs/configPropType';
 import ContentTable from '~/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable';
-import {structureData} from '~/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.utils';
 import {registry} from '@jahia/ui-extender';
 import {useLayoutQuery} from '@jahia/jcontent';
 import {cePickerSetTableViewType} from '~/SelectorTypes/Picker/Picker2.redux';
@@ -22,7 +21,7 @@ const unsetRefetcher = name => {
 
 export const ContentLayoutContainer = ({pickerConfig}) => {
     const {t} = useTranslation();
-    const {mode, path, filesMode, tableView, searchTerms, searchPath} = useSelector(state => ({
+    const {path, filesMode, tableView, searchTerms, searchPath} = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
         path: state.contenteditor.picker.path,
         filesMode: 'grid',
@@ -33,7 +32,7 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
     const dispatch = useDispatch();
     const canSelectPages = pickerConfig.selectableTypesTable.includes('jnt:page');
 
-    const {queryHandler, layoutQuery, isStructuredView, layoutQueryParams, data, error, loading, refetch} = useLayoutQuery(state => ({
+    const {layoutQuery, layoutQueryParams, result, error, loading, refetch} = useLayoutQuery(state => ({
         mode: state.contenteditor.picker.mode,
         siteKey: state.site,
         params: {
@@ -70,7 +69,7 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
             unsetRefetcher('pickerData');
         };
     });
-    if (error || (!loading && !queryHandler.getResultsPath(data))) {
+    if (error || (!loading && !result)) {
         if (error) {
             const message = t('jcontent:label.contentManager.error.queryingContent', {details: error.message || ''});
             console.error(message);
@@ -92,7 +91,7 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
     if (loading) {
         // While loading new results, render current ones loaded during previous render invocation (if any).
     } else {
-        currentResult = queryHandler.getResultsPath(data);
+        currentResult = result;
     }
 
     let rows = [];
@@ -100,11 +99,7 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
 
     if (currentResult) {
         totalCount = currentResult.pageInfo.totalCount;
-        if (isStructuredView && mode !== Constants.mode.SEARCH) {
-            rows = structureData(path, currentResult.nodes);
-        } else {
-            rows = currentResult.nodes;
-        }
+        rows = currentResult.nodes;
     }
 
     return (

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
@@ -32,7 +32,7 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
     const dispatch = useDispatch();
     const canSelectPages = pickerConfig.selectableTypesTable.includes('jnt:page');
 
-    const {layoutQuery, layoutQueryParams, result, error, loading, refetch} = useLayoutQuery(state => ({
+    const {layoutQuery, layoutQueryParams, result, error, loading, isStructured, refetch} = useLayoutQuery(state => ({
         mode: state.contenteditor.picker.mode,
         siteKey: state.site,
         params: {
@@ -82,6 +82,7 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
                           path={path}
                           filesMode={filesMode}
                           rows={[]}
+                          isStructured={isStructured}
                           isLoading={loading}
                           totalCount={0}
             />
@@ -114,6 +115,7 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
                           path={path}
                           filesMode={filesMode}
                           rows={rows}
+                          isStructured={isStructured}
                           isLoading={loading}
                           totalCount={totalCount}
             />

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
@@ -30,10 +30,6 @@ import {registry} from '@jahia/ui-extender';
 import {useFieldContext} from '~/contexts/FieldContext';
 import {configPropType} from '~/SelectorTypes/Picker/configs/configPropType';
 
-export const allowDoubleClickNavigation = nodeType => {
-    return (['jnt:folder', 'jnt:contentFolder'].indexOf(nodeType) !== -1);
-};
-
 const reduxActions = {
     onPreviewSelectAction: () => ({}),
     setOpenPathAction: path => cePickerOpenPaths(getDetailedPathArray(path)),
@@ -61,12 +57,12 @@ const clickHandler = {
 
 const SELECTION_COLUMN_ID = 'selection';
 
-export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, canSelectPages, pickerConfig}) => {
+export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, canSelectPages, pickerConfig, isStructured}) => {
     const {t} = useTranslation();
     const field = useFieldContext();
     const dispatch = useDispatch();
 
-    const {mode, path, pagination, tableView, searchTerm} = useSelector(state => ({
+    const {mode, path, pagination, searchTerm} = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
         path: state.contenteditor.picker.path,
         pagination: state.contenteditor.picker.pagination,
@@ -74,7 +70,10 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
         searchTerm: state.contenteditor.picker.searchTerms
     }), shallowEqual);
 
-    const isStructuredView = Constants.tableView.mode.STRUCTURED === tableView.viewMode;
+    const allowDoubleClickNavigation = nodeType => {
+        return !isStructured && (['jnt:folder', 'jnt:contentFolder'].indexOf(nodeType) !== -1);
+    };
+
     const columns = useMemo(() => {
         return allColumnData
             // Do not include type column if media mode
@@ -102,10 +101,10 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
     );
 
     useEffect(() => {
-        if (isStructuredView) {
+        if (isStructured) {
             toggleAllRowsExpanded(true);
         }
-    }, [rows, isStructuredView, toggleAllRowsExpanded]);
+    }, [rows, isStructured, toggleAllRowsExpanded]);
 
     const doubleClickNavigation = node => {
         const actions = [];
@@ -191,7 +190,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
                     </TableBody>
                 </Table>
             </UploadTransformComponent>
-            {!isStructuredView &&
+            {!isStructured &&
             <TablePagination totalNumberOfRows={totalCount}
                              currentPage={pagination.currentPage + 1}
                              rowsPerPage={pagination.pageSize}
@@ -210,6 +209,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
 ContentTable.propTypes = {
     isContentNotFound: PropTypes.bool,
     isLoading: PropTypes.bool,
+    isStructured: PropTypes.bool,
     rows: PropTypes.array.isRequired,
     totalCount: PropTypes.number.isRequired,
     canSelectPages: PropTypes.bool.isRequired,

--- a/src/javascript/SelectorTypes/Picker/accordionItems/queryHandlers.jsx
+++ b/src/javascript/SelectorTypes/Picker/accordionItems/queryHandlers.jsx
@@ -48,7 +48,7 @@ export const PickerTreeQueryHandler = {
         offset: 0,
         limit: 10000
     }),
-    getResults: (data, {path}) => BaseQueryHandler.structureData(path, BaseQueryHandler.getResults(data)),
+    isStructured: () => true,
     getFragments: () => [...BaseQueryHandler.getFragments(), selectableTypeFragment]
 };
 

--- a/src/javascript/SelectorTypes/Picker/accordionItems/queryHandlers.jsx
+++ b/src/javascript/SelectorTypes/Picker/accordionItems/queryHandlers.jsx
@@ -33,19 +33,22 @@ export function transformQueryHandler(queryHandler) {
 
 export const PickerContentsFolderQueryHandler = transformQueryHandler(ContentFoldersQueryHandler);
 
-export const PickersFilesQueryHandler = transformQueryHandler(FilesQueryHandler);
+export const PickerFilesQueryHandler = transformQueryHandler(FilesQueryHandler);
 
-export const PickersBaseQueryHandler = transformQueryHandler(BaseQueryHandler);
+export const PickerBaseQueryHandler = transformQueryHandler(BaseQueryHandler);
 
-export const PickerCategoryQueryHandler = {
+export const PickerTreeQueryHandler = {
     ...BaseQueryHandler,
     getQuery: () => BaseDescendantsQuery,
     getQueryParams: p => ({
         ...BaseQueryHandler.getQueryParams(p),
         selectableTypesTable: p.params.selectableTypesTable,
-        recursionTypesFilter: null,
-        typeFilter: Array.from(new Set([...p.params.selectableTypesTable, 'jnt:contentFolder', 'jnt:folder']))
+        typeFilter: p.params.selectableTypesTable,
+        recursionTypesFilter: {multi: 'NONE', types: []},
+        offset: 0,
+        limit: 10000
     }),
+    getResults: (data, {path}) => BaseQueryHandler.structureData(path, BaseQueryHandler.getResults(data)),
     getFragments: () => [...BaseQueryHandler.getFragments(), selectableTypeFragment]
 };
 
@@ -54,7 +57,7 @@ export const PickerPagesQueryHandler = {
     getQueryParams: p => ({
         ...PagesQueryHandler.getQueryParams(p),
         selectableTypesTable: p.params.selectableTypesTable,
-        typeFilter: Constants.tableView.type.PAGES === p.viewType ? ['jnt:page'] : p.params.selectableTypesTable.filter(t => t !== 'jnt:page')
+        typeFilter: Constants.tableView.type.PAGES === p.tableView.viewType ? ['jnt:page'] : p.params.selectableTypesTable.filter(t => t !== 'jnt:page')
     }),
     getFragments: () => [...PagesQueryHandler.getFragments(), selectableTypeFragment]
 };

--- a/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
+++ b/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
@@ -32,7 +32,8 @@ export const registerPickerConfig = ceRegistry => {
         },
         pickerDialog: {
             dialogTitle: 'content-editor:label.contentEditor.edit.fields.contentPicker.modalFileTitle',
-            searchPlaceholder: 'content-editor:label.contentEditor.edit.fields.contentPicker.searchFilePlaceholder'
+            searchPlaceholder: 'content-editor:label.contentEditor.edit.fields.contentPicker.searchFilePlaceholder',
+            displayTree: false
         },
         searchSelectorType: 'jnt:folder',
         selectableTypesTable: ['jnt:folder']
@@ -40,13 +41,17 @@ export const registerPickerConfig = ceRegistry => {
 
     ceRegistry.add(Constants.pickerConfig, 'contentfolder', mergeDeep({}, ContentPickerConfig, {
         pickerDialog: {
-            dialogTitle: 'content-editor:label.contentEditor.edit.fields.contentPicker.modalFolderTitle'
+            dialogTitle: 'content-editor:label.contentEditor.edit.fields.contentPicker.modalFolderTitle',
+            displayTree: false
         },
         searchSelectorType: 'jnt:contentFolder',
         selectableTypesTable: ['jnt:contentFolder']
     }));
 
     ceRegistry.add(Constants.pickerConfig, 'page', mergeDeep({}, ContentPickerConfig, {
+        pickerDialog: {
+            displayTree: false
+        },
         searchSelectorType: 'jnt:page',
         selectableTypesTable: ['jnt:page']
     }));

--- a/src/javascript/SelectorTypes/Picker/reactTable/plugins/useExpanded.jsx
+++ b/src/javascript/SelectorTypes/Picker/reactTable/plugins/useExpanded.jsx
@@ -64,9 +64,11 @@ const defaultGetToggleRowExpandedProps = (props, {row}) => [
     props,
     {
         onClick: e => {
-            e.preventDefault();
-            e.stopPropagation();
-            row.toggleRowExpanded();
+            if (e.target.matches('.moonstone-TableCell > svg') || e.target.matches('.moonstone-TableCell > svg *')) {
+                e.preventDefault();
+                e.stopPropagation();
+                row.toggleRowExpanded();
+            }
         },
         style: {
             cursor: 'pointer'
@@ -156,7 +158,7 @@ function useInstance(instance) {
         manualExpandedKey = 'expanded',
         paginateExpandedRows = true,
         expandSubRows = true,
-        autoResetExpanded = true,
+        autoResetExpanded = false,
         getHooks,
         plugins,
         state: {expanded},


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17381

## Description

Adapted useLayoutQuery usage.
Add picker-pages-tree , picker-conten-folder-tree and picker-folder-tree accordions . Also adapt picker-category and reformatted accordionItems code.
Adapted picker configs
Fixed the "useExpanded" so that we can select without expanding and expand without selecting.
