### PR TITLE
BACKLOG-19924: Add site switcher and openable types in tree

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog2.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog2.jsx
@@ -6,19 +6,18 @@ import {
     cePickerClearSelection,
     cePickerKey,
     cePickerMode,
-    cePickerOpenPaths,
-    cePickerPath, cePickerSetSearchTerm,
-    cePickerSite
+    cePickerPath,
+    cePickerSetSearchTerm
 } from '~/SelectorTypes/Picker/Picker2.redux';
 import {getItemTarget} from '~/SelectorTypes/Picker/accordionItems/accordionItems';
 import {batchActions} from 'redux-batched-actions';
 import {configPropType} from '~/SelectorTypes/Picker/configs/configPropType';
-import {booleanValue, getDetailedPathArray} from '~/SelectorTypes/Picker/Picker2.utils';
-import {registry} from '@jahia/ui-extender';
-import {shallowEqual, useDispatch, useSelector} from 'react-redux';
+import {booleanValue} from '~/SelectorTypes/Picker/Picker2.utils';
+import {useDispatch} from 'react-redux';
 import RightPanel from './RightPanel';
-import {ContentNavigation, SiteSwitcher} from '@jahia/jcontent';
+import {ContentNavigation} from '@jahia/jcontent';
 import {SelectionHandler} from '~/SelectorTypes/Picker/PickerDialog/SelectionHandler';
+import {PickerSiteSwitcher} from '~/SelectorTypes/Picker/PickerDialog/PickerSiteSwitcher';
 
 const Transition = props => {
     return <Slide direction="up" {...props}/>;
@@ -30,11 +29,6 @@ const selector = state => ({
     language: state.language
 });
 
-const switcherSelector = state => ({
-    siteKey: state.contenteditor.picker.site,
-    currentLang: state.language
-});
-
 export const PickerDialog = ({
     isOpen,
     onClose,
@@ -44,16 +38,6 @@ export const PickerDialog = ({
     accordionItemProps,
     onItemSelection
 }) => {
-    const state = useSelector(state => ({
-        mode: state.contenteditor.picker.mode,
-        path: state.contenteditor.picker.path,
-        openPaths: state.contenteditor.picker.openPaths,
-        site: state.contenteditor.picker.site,
-        contextSite: state.contenteditor.picker.contextSite,
-        jcontentMode: state.jcontent.mode,
-        jcontentPath: state.jcontent.path
-    }), shallowEqual);
-
     const dispatch = useDispatch();
     useEffect(() => {
         if (isOpen) {
@@ -88,21 +72,7 @@ export const PickerDialog = ({
                                 isReversed={false}
                                 header={(booleanValue(pickerConfig.pickerDialog.displaySiteSwitcher) && (
                                     <div>
-                                        <SiteSwitcher selector={switcherSelector}
-                                                      onSelectAction={siteNode => {
-                                                          const actions = [];
-                                                          actions.push(cePickerSite(siteNode.name));
-                                                          const accordionItems = registry.find({type: 'accordionItem', target: getItemTarget(pickerConfig.key)})
-                                                              .filter(accordionItem => !accordionItem.isEnabled || accordionItem.isEnabled(siteNode.name));
-                                                          const selectedAccordion = accordionItems.find(item => item.key === state.mode) || accordionItems[0];
-                                                          const newPath = selectedAccordion.defaultPath(siteNode.name);
-                                                          actions.push(cePickerPath(newPath));
-                                                          actions.push(cePickerMode(selectedAccordion.key));
-                                                          actions.push(cePickerOpenPaths([...state.openPaths, ...getDetailedPathArray(newPath, siteNode.name)]));
-
-                                                          return batchActions(actions);
-                                                      }}
-                                        />
+                                        <PickerSiteSwitcher pickerConfig={pickerConfig}/>
                                     </div>
                                 ))}
                                 accordionItemTarget={getItemTarget(pickerConfig.key)}

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/PickerSiteSwitcher.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/PickerSiteSwitcher.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {shallowEqual, useSelector} from 'react-redux';
+import {cePickerMode, cePickerOpenPaths, cePickerPath, cePickerSite} from '~/SelectorTypes/Picker/Picker2.redux';
+import {registry} from '@jahia/ui-extender';
+import {getItemTarget} from '~/SelectorTypes/Picker/accordionItems/accordionItems';
+import {getDetailedPathArray} from '~/SelectorTypes/Picker/Picker2.utils';
+import {batchActions} from 'redux-batched-actions';
+import {SiteSwitcher} from '@jahia/jcontent';
+import {configPropType} from '~/SelectorTypes/Picker/configs/configPropType';
+
+const switcherSelector = state => ({
+    siteKey: state.contenteditor.picker.site,
+    currentLang: state.language
+});
+
+export const PickerSiteSwitcher = ({pickerConfig}) => {
+    const state = useSelector(state => ({
+        mode: state.contenteditor.picker.mode,
+        openPaths: state.contenteditor.picker.openPaths
+    }), shallowEqual);
+
+    return (
+        <SiteSwitcher selector={switcherSelector}
+                      onSelectAction={siteNode => {
+                          const actions = [];
+                          actions.push(cePickerSite(siteNode.name));
+                          const accordionItems = registry.find({
+                              type: 'accordionItem',
+                              target: getItemTarget(pickerConfig.key)
+                          })
+                              .filter(accordionItem => !accordionItem.isEnabled || accordionItem.isEnabled(siteNode.name));
+                          const selectedAccordion = accordionItems.find(item => item.key === state.mode) || accordionItems[0];
+                          const newPath = selectedAccordion.defaultPath(siteNode.name);
+                          actions.push(cePickerPath(newPath));
+                          actions.push(cePickerMode(selectedAccordion.key));
+                          actions.push(cePickerOpenPaths([...state.openPaths, ...getDetailedPathArray(newPath, siteNode.name)]));
+
+                          return batchActions(actions);
+                      }}
+        />
+    );
+};
+
+PickerSiteSwitcher.propTypes = {
+    pickerConfig: configPropType.isRequired
+};

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
@@ -21,7 +21,7 @@ const unsetRefetcher = name => {
 
 export const ContentLayoutContainer = ({pickerConfig}) => {
     const {t} = useTranslation();
-    const {path, filesMode, tableView, searchTerms, searchPath} = useSelector(state => ({
+    const {mode, path, filesMode, tableView, searchTerms, searchPath} = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
         path: state.contenteditor.picker.path,
         filesMode: 'grid',
@@ -31,24 +31,28 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
     }), shallowEqual);
     const dispatch = useDispatch();
     const canSelectPages = pickerConfig.selectableTypesTable.includes('jnt:page');
+    const openableTypes = registry.get('accordionItem', mode)?.config?.openableTypes;
 
-    const {layoutQuery, layoutQueryParams, result, error, loading, isStructured, refetch} = useLayoutQuery(state => ({
-        mode: state.contenteditor.picker.mode,
-        siteKey: state.site,
-        params: {
-            searchTerms,
-            searchPath,
-            searchContentType: pickerConfig.searchSelectorType,
-            selectableTypesTable: pickerConfig.selectableTypesTable
-        },
-        path: state.contenteditor.picker.path,
-        lang: state.language,
-        uilang: state.uilang,
-        filesMode: 'grid',
-        pagination: state.contenteditor.picker.pagination,
-        sort: state.contenteditor.picker.sort,
-        tableView: state.contenteditor.picker.tableView
-    }));
+    const {layoutQuery, layoutQueryParams, result, error, loading, isStructured, refetch} = useLayoutQuery(state => {
+        return ({
+            mode: state.contenteditor.picker.mode,
+            siteKey: state.site,
+            params: {
+                searchTerms,
+                searchPath,
+                searchContentType: pickerConfig.searchSelectorType,
+                selectableTypesTable: pickerConfig.selectableTypesTable,
+                openableTypes
+            },
+            path: state.contenteditor.picker.path,
+            lang: state.language,
+            uilang: state.uilang,
+            filesMode: 'grid',
+            pagination: state.contenteditor.picker.pagination,
+            sort: state.contenteditor.picker.sort,
+            tableView: state.contenteditor.picker.tableView
+        });
+    });
 
     // Reset table view type to content if pages cannot be picked, we do not show table view selector if pages cannot
     // be picked

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
@@ -5,7 +5,12 @@ import {useTranslation} from 'react-i18next';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import {Table, TableBody, TablePagination, TableRow} from '@jahia/moonstone';
 import {useTable} from 'react-table';
-import {useExpanded, useRowMultipleSelection, useRowSelection, useSort} from '~/SelectorTypes/Picker/reactTable/plugins';
+import {
+    useExpanded,
+    useRowMultipleSelection,
+    useRowSelection,
+    useSort
+} from '~/SelectorTypes/Picker/reactTable/plugins';
 import {allColumnData} from '~/SelectorTypes/Picker/reactTable/columns';
 import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
 import {
@@ -89,7 +94,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
         headerGroups,
         rows: tableRows,
         prepareRow,
-        toggleAllRowsExpanded
+        toggleRowExpanded
     } = useTable(
         {
             columns: columns,
@@ -102,9 +107,9 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
 
     useEffect(() => {
         if (isStructured) {
-            toggleAllRowsExpanded(true);
+            toggleRowExpanded(0, true);
         }
-    }, [rows, isStructured, toggleAllRowsExpanded]);
+    }, [rows, isStructured, toggleRowExpanded]);
 
     const doubleClickNavigation = node => {
         const actions = [];

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -11,6 +11,7 @@ import {DisplayActions, registry} from '@jahia/ui-extender';
 import {getButtonRenderer} from '~/utils';
 import {SelectionCaption, SelectionTable} from './PickerSelection';
 import {Search} from './Search';
+import {PickerSiteSwitcher} from '~/SelectorTypes/Picker';
 
 const ButtonRenderer = getButtonRenderer({defaultButtonProps: {variant: 'ghost'}});
 
@@ -40,6 +41,7 @@ const RightPanel = ({pickerConfig, onClose, onItemSelection}) => {
             <header className={clsx('flexCol_nowrap', css.header)}>
                 <Typography variant="heading">Select content</Typography>
                 <div className={clsx('flexRow_nowrap', 'alignCenter', css.headerActions)}>
+                    {!pickerConfig.pickerDialog.displayTree && pickerConfig.pickerDialog.displaySiteSwitcher && <PickerSiteSwitcher pickerConfig={pickerConfig}/>}
                     <Search pickerConfig={pickerConfig}/>
                     <div className="flexFluid"/>
                     <DisplayActions target={actionsTarget} render={ButtonRenderer} path={path}/>

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/index.js
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/index.js
@@ -1,2 +1,3 @@
 export * from './PickerDialog2';
 export {GET_PICKER_NODE} from '~/SelectorTypes/Picker/PickerDialog/PickerDialog2.gql-queries';
+export {PickerSiteSwitcher} from '~/SelectorTypes/Picker/PickerDialog/PickerSiteSwitcher';

--- a/src/javascript/SelectorTypes/Picker/accordionItems/accordionItems.jsx
+++ b/src/javascript/SelectorTypes/Picker/accordionItems/accordionItems.jsx
@@ -99,7 +99,6 @@ export const registerAccordionItems = registry => {
             viewSelector: null,
             tableHeader: null,
             targets: ['page:50'],
-            openableTypes: ['jnt:page', 'jnt:virtualsite', 'jnt:navMenuText'],
             getSearchContextData,
             queryHandler: PickerTreeQueryHandler
         }, renderer);

--- a/src/javascript/SelectorTypes/Picker/accordionItems/accordionItems.jsx
+++ b/src/javascript/SelectorTypes/Picker/accordionItems/accordionItems.jsx
@@ -99,6 +99,7 @@ export const registerAccordionItems = registry => {
             viewSelector: null,
             tableHeader: null,
             targets: ['page:50'],
+            openableTypes: ['jnt:page', 'jnt:virtualsite', 'jnt:navMenuText'],
             getSearchContextData,
             queryHandler: PickerTreeQueryHandler
         }, renderer);

--- a/src/javascript/SelectorTypes/Picker/accordionItems/queryHandlers.jsx
+++ b/src/javascript/SelectorTypes/Picker/accordionItems/queryHandlers.jsx
@@ -25,7 +25,7 @@ export function transformQueryHandler(queryHandler) {
         getQueryParams: p => ({
             ...queryHandler.getQueryParams(p),
             selectableTypesTable: p.params.selectableTypesTable,
-            typeFilter: Array.from(new Set([...p.params.selectableTypesTable, 'jnt:contentFolder', 'jnt:folder']))
+            typeFilter: Array.from(new Set([...p.params.selectableTypesTable, ...p.params.openableTypes]))
         }),
         getFragments: () => [...queryHandler.getFragments(), selectableTypeFragment]
     };
@@ -43,7 +43,7 @@ export const PickerTreeQueryHandler = {
     getQueryParams: p => ({
         ...BaseQueryHandler.getQueryParams(p),
         selectableTypesTable: p.params.selectableTypesTable,
-        typeFilter: p.params.selectableTypesTable,
+        typeFilter: Array.from(new Set([...p.params.selectableTypesTable, ...p.params.openableTypes])),
         recursionTypesFilter: {multi: 'NONE', types: []},
         offset: 0,
         limit: 10000

--- a/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
+++ b/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
@@ -35,6 +35,9 @@ export const registerPickerConfig = ceRegistry => {
             searchPlaceholder: 'content-editor:label.contentEditor.edit.fields.contentPicker.searchFilePlaceholder',
             displayTree: false
         },
+        pickerTable: {
+            columns: ['name', 'lastModified']
+        },
         searchSelectorType: 'jnt:folder',
         selectableTypesTable: ['jnt:folder']
     }));
@@ -44,6 +47,9 @@ export const registerPickerConfig = ceRegistry => {
             dialogTitle: 'content-editor:label.contentEditor.edit.fields.contentPicker.modalFolderTitle',
             displayTree: false
         },
+        pickerTable: {
+            columns: ['name', 'lastModified']
+        },
         searchSelectorType: 'jnt:contentFolder',
         selectableTypesTable: ['jnt:contentFolder']
     }));
@@ -51,6 +57,9 @@ export const registerPickerConfig = ceRegistry => {
     ceRegistry.add(Constants.pickerConfig, 'page', mergeDeep({}, ContentPickerConfig, {
         pickerDialog: {
             displayTree: false
+        },
+        pickerTable: {
+            columns: ['name', 'lastModified']
         },
         searchSelectorType: 'jnt:page',
         selectableTypesTable: ['jnt:page']


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19924

## Description

- Add site switcher
- Add openable types in table ( navMenuItem for page picker, folder and content folder )
- Automatically expand first node only
- Set columns