### PR TITLE
BACKLOG-19953: Fix cypress container script

### DIFF
--- a/tests/env.run.sh
+++ b/tests/env.run.sh
@@ -77,9 +77,10 @@ do
   curl -u root:${SUPER_USER_PASSWORD} -X POST ${JAHIA_URL}/modules/api/provisioning --form script='[{"executeScript":"'"$file"'"}]' --form file=@$file
   echo "$(date +'%d %B %Y - %k:%M') [SCRIPT] == Script executed =="
 done
+cd ..
 
 echo "$(date +'%d %B %Y - %k:%M') == Fetching the list of installed modules =="
-./node_modules/@jahia/jahia-reporter/bin/run utils:modules \
+~/node_modules/@jahia/jahia-reporter/bin/run utils:modules \
   --moduleId="${MODULE_ID}" \
   --jahiaUrl="${JAHIA_URL}" \
   --jahiaPassword="${SUPER_USER_PASSWORD}" \


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19953

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Current directory was changed when we added groovy script execution [here](https://github.com/Jahia/content-editor/pull/1265/files?w=1) which was causing the `jahia-reporter` execution to fail.

Fixed to go back to home directory, and also for `jahia-reporter` to use home directory in path instead of current dir.