### PR TITLE
BACKLOG-19937: Fallback to default configuration if it does not exist or if it is a legacy configuration

### DIFF
--- a/src/javascript/SelectorTypes/Picker/registerPicker.js
+++ b/src/javascript/SelectorTypes/Picker/registerPicker.js
@@ -13,10 +13,10 @@ export const getPickerSelectorType = (registry, options) => {
 
     if (!pickerConfig) {
         console.warn('Picker configuration not found', pickerConfigKey);
-        pickerConfig = registry.get(Constants.pickerConfig, 'editorial');
+        pickerConfig = registry.get(Constants.pickerConfig, 'default');
     } else if (pickerConfig.cmp) {
         console.warn('Legacy picker configuration found', pickerConfigKey);
-        pickerConfig = registry.get(Constants.pickerConfig, 'editorial');
+        pickerConfig = registry.get(Constants.pickerConfig, 'default');
     }
 
     return ({


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19937

## Description
while testing custom pickers with selenium I noticed we were using editorial picker which causing even more issues than if it was default

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
