### PR TITLE
BACKLOG-17575: check page type in ContentTypeSelector

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
@@ -1,13 +1,12 @@
 import React, {useEffect} from 'react';
 import {useTranslation} from 'react-i18next';
-import {shallowEqual, useDispatch, useSelector} from 'react-redux';
+import {shallowEqual, useSelector} from 'react-redux';
 import {Loader} from '@jahia/moonstone';
 import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
 import {configPropType} from '~/SelectorTypes/Picker/configs/configPropType';
 import ContentTable from '~/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable';
 import {registry} from '@jahia/ui-extender';
 import {useLayoutQuery} from '@jahia/jcontent';
-import {cePickerSetTableViewType} from '~/SelectorTypes/Picker/Picker2.redux';
 
 let currentResult;
 
@@ -21,7 +20,7 @@ const unsetRefetcher = name => {
 
 export const ContentLayoutContainer = ({pickerConfig}) => {
     const {t} = useTranslation();
-    const {mode, path, filesMode, tableView, preSearchModeMemo, searchTerms, searchPath} = useSelector(state => ({
+    const {mode, path, filesMode, preSearchModeMemo, searchTerms, searchPath} = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
         path: state.contenteditor.picker.path,
         filesMode: 'grid',
@@ -30,8 +29,6 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
         searchTerms: state.contenteditor.picker.searchTerms,
         searchPath: state.contenteditor.picker.searchPath
     }), shallowEqual);
-    const dispatch = useDispatch();
-    const canSelectPages = pickerConfig.selectableTypesTable.includes('jnt:page');
     const openableTypes = registry.get('accordionItem', mode)?.config?.openableTypes;
 
     const additionalFragments = [];
@@ -58,14 +55,6 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
         tableView: state.contenteditor.picker.tableView
     }), {}, additionalFragments);
 
-    // Reset table view type to content if pages cannot be picked, we do not show table view selector if pages cannot
-    // be picked
-    useEffect(() => {
-        if (!canSelectPages && tableView.viewType === Constants.tableView.type.PAGES) {
-            dispatch(cePickerSetTableViewType(Constants.tableView.type.CONTENT));
-        }
-    }, [dispatch, canSelectPages, tableView.viewType]);
-
     useEffect(() => {
         setRefetcher('pickerData', {
             query: layoutQuery,
@@ -86,7 +75,6 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
         return (
             <ContentTable isContentNotFound
                           pickerConfig={pickerConfig}
-                          canSelectPages={canSelectPages}
                           path={path}
                           filesMode={filesMode}
                           rows={[]}
@@ -119,7 +107,6 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
                 </div>
             )}
             <ContentTable pickerConfig={pickerConfig}
-                          canSelectPages={canSelectPages}
                           path={path}
                           filesMode={filesMode}
                           rows={rows}

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
@@ -63,7 +63,7 @@ const clickHandler = {
 
 const SELECTION_COLUMN_ID = 'selection';
 
-export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, canSelectPages, pickerConfig, isStructured}) => {
+export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, pickerConfig, isStructured}) => {
     const {t} = useTranslation();
     const field = useFieldContext();
     const dispatch = useDispatch();
@@ -162,7 +162,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
 
         return (
             <>
-                {canSelectPages && tableHeader}
+                {tableHeader}
                 <ContentEmptyDropZone mode={mode} path={path}/>
             </>
         );
@@ -183,7 +183,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, ca
 
     return (
         <>
-            {canSelectPages && tableHeader}
+            {tableHeader}
             <UploadTransformComponent uploadTargetComponent={ContentTableWrapper}
                                       reference={mainPanelRef}
                                       uploadPath={path}
@@ -242,7 +242,6 @@ ContentTable.propTypes = {
     isStructured: PropTypes.bool,
     rows: PropTypes.array.isRequired,
     totalCount: PropTypes.number.isRequired,
-    canSelectPages: PropTypes.bool.isRequired,
     pickerConfig: configPropType.isRequired
 };
 

--- a/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
+++ b/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
@@ -11,7 +11,7 @@ import {registerMediaPickers} from './mediaPicker/mediaPicker';
 import {registerEditorialLinkPicker} from './editorialLinkPicker';
 import {registerPagePicker} from '~/SelectorTypes/Picker/configs/pagePicker';
 import {PickerSearchQueryHandler} from '~/SelectorTypes/Picker/configs/queryHandlers';
-import {registerEditorialPicker} from '~/SelectorTypes/Picker/configs/editorialPicker';
+import {registerEditorialPicker} from '~/SelectorTypes/Picker/configs/editorialPicker/editorialPicker';
 
 export const registerPickerConfig = registry => {
     registry.add(Constants.pickerConfig, 'default', mergeDeep({}, ContentPickerConfig, {

--- a/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/EditorialLinkContentTypeSelector.jsx
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/EditorialLinkContentTypeSelector.jsx
@@ -5,13 +5,17 @@ import classes from './EditorialLinkContentTypeSelector.scss';
 import {useTranslation} from 'react-i18next';
 import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
 import {cePickerSetTableViewType} from '~/SelectorTypes/Picker/Picker2.redux';
+import {registry} from '@jahia/ui-extender';
 
 const localStorage = window.localStorage;
 
 const EditorialLinkContentTypeSelector = () => {
     const {t} = useTranslation('content-editor');
     const tableView = useSelector(state => state.contenteditor.picker.tableView);
+    const pickerKey = useSelector(state => state.contenteditor.picker.pickerKey);
     const dispatch = useDispatch();
+
+    const selectableTypesTable = registry.get('pickerConfiguration', pickerKey)?.selectableTypesTable || [];
 
     const {CONTENT, PAGES} = Constants.tableView.type;
     const LOCAL_STORAGE_VIEW_TYPE_KEY = 'jcontent_view_type';
@@ -21,7 +25,9 @@ const EditorialLinkContentTypeSelector = () => {
         localStorage.setItem(LOCAL_STORAGE_VIEW_TYPE_KEY, viewType);
     };
 
-    return (
+    const canSelectPages = selectableTypesTable.includes('jnt:page');
+
+    return canSelectPages && (
         <Tab className={classes.tabs}>
             <TabItem isSelected={PAGES === tableView.viewType}
                      data-cm-view-type={PAGES}

--- a/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
@@ -13,7 +13,7 @@ export const PickerEditorialLinkQueryHandler = {
             fieldGrouping: null
         };
 
-        if (selection.tableView.viewType === Constants.tableView.type.PAGES) {
+        if (selection.params.selectableTypesTable.includes('jnt:page') && selection.tableView.viewType === Constants.tableView.type.PAGES) {
             queryParams.typeFilter = ['jnt:page', 'jmix:mainResource'];
             queryParams.recursionTypesFilter = {multi: 'NONE', types: ['jnt:contentFolder']};
         } else { // Content

--- a/src/javascript/SelectorTypes/Picker/configs/editorialPicker/EditorialContentTypeSelector.js
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialPicker/EditorialContentTypeSelector.js
@@ -1,0 +1,36 @@
+import {useSelector} from 'react-redux';
+import {registry} from '@jahia/ui-extender';
+import {cePickerSetPage, cePickerSetTableViewType} from '~/SelectorTypes/Picker/Picker2.redux';
+import React from 'react';
+import {ContentTypeSelector as JContentTypeSelector} from '@jahia/jcontent';
+
+export const EditorialContentTypeSelector = () => {
+    const pickerKey = useSelector(state => state.contenteditor.picker.pickerKey);
+    const selectableTypesTable = registry.get('pickerConfiguration', pickerKey)?.selectableTypesTable || [];
+
+    const selector = state => {
+        return ({
+            mode: state.contenteditor.picker.mode,
+            siteKey: state.site,
+            path: state.contenteditor.picker.path,
+            lang: state.language,
+            uilang: state.uilang,
+            params: {
+                selectableTypesTable: selectableTypesTable
+            },
+            pagination: state.contenteditor.picker.pagination,
+            sort: state.contenteditor.picker.sort,
+            tableView: state.contenteditor.picker.tableView
+        });
+    };
+
+    const reduxActions = {
+        setPageAction: page => cePickerSetPage(page),
+        setTableViewTypeAction: view => cePickerSetTableViewType(view)
+    };
+
+    const canSelectPages = selectableTypesTable.includes('jnt:page');
+
+    return canSelectPages && <JContentTypeSelector selector={selector} reduxActions={reduxActions}/>;
+};
+

--- a/src/javascript/SelectorTypes/Picker/configs/editorialPicker/PickerPagesQueryHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialPicker/PickerPagesQueryHandler.jsx
@@ -1,0 +1,13 @@
+import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
+import {PagesQueryHandler} from '@jahia/jcontent';
+import {selectableTypeFragment} from '~/SelectorTypes/Picker/configs/queryHandlers';
+
+export const PickerPagesQueryHandler = {
+    ...PagesQueryHandler,
+    getQueryParams: p => ({
+        ...PagesQueryHandler.getQueryParams(p),
+        selectableTypesTable: p.params.selectableTypesTable,
+        typeFilter: p.params.selectableTypesTable.includes('jnt:page') && Constants.tableView.type.PAGES === p.tableView.viewType ? ['jnt:page'] : p.params.selectableTypesTable.filter(t => t !== 'jnt:page')
+    }),
+    getFragments: () => [...PagesQueryHandler.getFragments(), selectableTypeFragment]
+};

--- a/src/javascript/SelectorTypes/Picker/configs/editorialPicker/editorialPicker.js
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialPicker/editorialPicker.js
@@ -2,16 +2,13 @@ import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
 import {mergeDeep} from '~/SelectorTypes/Picker/Picker2.utils';
 import {ContentPickerConfig} from '~/SelectorTypes/Picker/configs/ContentPickerConfig';
 import {getPagesSearchContextData} from '~/SelectorTypes/Picker/configs/getPagesSearchContextData';
-import {PickerContentsFolderQueryHandler, PickerPagesQueryHandler} from '~/SelectorTypes/Picker/configs/queryHandlers';
+import {transformQueryHandler} from '~/SelectorTypes/Picker/configs/queryHandlers';
 import {renderer} from '~/SelectorTypes/Picker/configs/renderer';
 import React from 'react';
-import {registry} from '@jahia/ui-extender';
-import {ContentTypeSelector as JContentTypeSelector, ViewModeSelector} from '@jahia/jcontent';
-import {
-    cePickerSetPage,
-    cePickerSetTableViewMode,
-    cePickerSetTableViewType
-} from '~/SelectorTypes/Picker/Picker2.redux';
+import {ContentFoldersQueryHandler, ViewModeSelector} from '@jahia/jcontent';
+import {cePickerSetTableViewMode} from '~/SelectorTypes/Picker/Picker2.redux';
+import {EditorialContentTypeSelector} from './EditorialContentTypeSelector';
+import {PickerPagesQueryHandler} from '~/SelectorTypes/Picker/configs/editorialPicker/PickerPagesQueryHandler';
 
 const viewModeSelectorProps = {
     selector: state => ({
@@ -21,25 +18,7 @@ const viewModeSelectorProps = {
     setTableViewModeAction: mode => cePickerSetTableViewMode(mode)
 };
 
-const contentTypeSelectorProps = {
-    selector: state => ({
-        mode: state.contenteditor.picker.mode,
-        siteKey: state.site,
-        path: state.contenteditor.picker.path,
-        lang: state.language,
-        uilang: state.uilang,
-        params: {
-            selectableTypesTable: registry.get('pickerConfiguration', state.contenteditor.picker.pickerKey)?.selectableTypesTable || []
-        },
-        pagination: state.contenteditor.picker.pagination,
-        sort: state.contenteditor.picker.sort,
-        tableView: state.contenteditor.picker.tableView
-    }),
-    reduxActions: {
-        setPageAction: page => cePickerSetPage(page),
-        setTableViewTypeAction: view => cePickerSetTableViewType(view)
-    }
-};
+const PickerContentsFolderQueryHandler = transformQueryHandler(ContentFoldersQueryHandler);
 
 export const registerEditorialPicker = registry => {
     registry.add(Constants.pickerConfig, 'editorial', mergeDeep({}, ContentPickerConfig, {
@@ -56,7 +35,7 @@ export const registerEditorialPicker = registry => {
         registry.add(Constants.ACCORDION_ITEM_NAME, `picker-${Constants.ACCORDION_ITEM_TYPES.PAGES}`, {
             ...pagesItem,
             viewSelector: <ViewModeSelector {...viewModeSelectorProps}/>,
-            tableHeader: <JContentTypeSelector {...contentTypeSelectorProps}/>,
+            tableHeader: <EditorialContentTypeSelector/>,
             targets: ['default:50', 'editorial:50'],
             defaultSort: {orderBy: 'lastModified.value', order: 'DESC'},
             getSearchContextData: getPagesSearchContextData,

--- a/src/javascript/SelectorTypes/Picker/configs/editorialPicker/index.js
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialPicker/index.js
@@ -1,0 +1,4 @@
+export * from './editorialPicker';
+export {
+    EditorialContentTypeSelector
+} from '~/SelectorTypes/Picker/configs/editorialPicker/EditorialContentTypeSelector';

--- a/src/javascript/SelectorTypes/Picker/configs/queryHandlers.jsx
+++ b/src/javascript/SelectorTypes/Picker/configs/queryHandlers.jsx
@@ -1,14 +1,7 @@
-import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
-import {
-    BaseDescendantsQuery,
-    BaseQueryHandler,
-    ContentFoldersQueryHandler,
-    PagesQueryHandler,
-    SearchQueryHandler
-} from '@jahia/jcontent';
+import {BaseDescendantsQuery, BaseQueryHandler, SearchQueryHandler} from '@jahia/jcontent';
 import gql from 'graphql-tag';
 
-const selectableTypeFragment = {
+export const selectableTypeFragment = {
     gql: gql`fragment IsSelectable on JCRNode {
         isSelectable: isNodeType(type: {types: $selectableTypesTable})
     }`,
@@ -30,8 +23,6 @@ export function transformQueryHandler(queryHandler) {
     };
 }
 
-export const PickerContentsFolderQueryHandler = transformQueryHandler(ContentFoldersQueryHandler);
-
 export const PickerBaseQueryHandler = transformQueryHandler(BaseQueryHandler);
 
 export const PickerTreeQueryHandler = transformQueryHandler({
@@ -45,16 +36,6 @@ export const PickerTreeQueryHandler = transformQueryHandler({
     }),
     isStructured: () => true
 });
-
-export const PickerPagesQueryHandler = {
-    ...PagesQueryHandler,
-    getQueryParams: p => ({
-        ...PagesQueryHandler.getQueryParams(p),
-        selectableTypesTable: p.params.selectableTypesTable,
-        typeFilter: Constants.tableView.type.PAGES === p.tableView.viewType ? ['jnt:page'] : p.params.selectableTypesTable.filter(t => t !== 'jnt:page')
-    }),
-    getFragments: () => [...PagesQueryHandler.getFragments(), selectableTypeFragment]
-};
 
 export const PickerSearchQueryHandler = transformQueryHandler({
     ...SearchQueryHandler,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17575

## Description

Every ContentTypeSelector can define its own rules to be displayed or not, ContentLayout.container cannot hide generic header based on custom rule. Ensure the query does not use viewType if selector is not defined ( for editorial and editorialLink )