### PR TITLE
BACKLOG-19992: Do not recurse into files folder of sites

### DIFF
--- a/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
@@ -15,7 +15,7 @@ export const PickerEditorialLinkQueryHandler = {
             treeParams.selectableTypes = ['jmix:mainResource'];
         }
 
-        treeParams.recursionTypesFilter = {multi: 'NONE', types: ['jnt:contentFolder', 'jnt:page']};
+        treeParams.recursionTypesFilter = {multi: 'NONE', types: ['jnt:contentFolder', 'jnt:page', 'jnt:folder']};
 
         return treeParams;
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19992

## Description

Mount a folder with lots folders/files (I have my modules folder mounted under /var/jahia/sources) the editorialpicker will recurse in the files folder and try to find pages and mainResource in there but as jnt:folder is not excluded it keeps going down the rabbit hole

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
