### PR TITLE
BACKLOG-17389: Add refresh to pickers

### DIFF
--- a/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
+++ b/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
@@ -51,5 +51,12 @@ export const registerPickerConfig = registry => {
         registry.get('action', 'createFolder')?.targets?.push({id: 'content-editor/pickers/picker-media/header-actions', priority: 2});
         registry.get('action', 'fileUpload')?.targets?.push({id: 'content-editor/pickers/picker-media/header-actions', priority: 3});
         registry.get('action', 'refresh')?.targets?.push({id: 'content-editor/pickers/picker-media/header-actions', priority: 4});
+
+        const refresh = registry.get('action', 'refresh')
+        if (refresh) {
+            Object.values(Constants.ACCORDION_ITEM_TYPES).forEach(type => {
+                refresh.targets.push({id: `content-editor/pickers/picker-${type}/header-actions`, priority: 0})
+            });
+        }
     });
 };

--- a/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
+++ b/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
@@ -52,10 +52,10 @@ export const registerPickerConfig = registry => {
         registry.get('action', 'fileUpload')?.targets?.push({id: 'content-editor/pickers/picker-media/header-actions', priority: 3});
         registry.get('action', 'refresh')?.targets?.push({id: 'content-editor/pickers/picker-media/header-actions', priority: 4});
 
-        const refresh = registry.get('action', 'refresh')
+        const refresh = registry.get('action', 'refresh');
         if (refresh) {
             Object.values(Constants.ACCORDION_ITEM_TYPES).forEach(type => {
-                refresh.targets.push({id: `content-editor/pickers/picker-${type}/header-actions`, priority: 0})
+                refresh.targets.push({id: `content-editor/pickers/picker-${type}/header-actions`, priority: 0});
             });
         }
     });

--- a/tests/cypress/e2e/pickers/displayActions.cy.ts
+++ b/tests/cypress/e2e/pickers/displayActions.cy.ts
@@ -1,0 +1,89 @@
+import {contentTypes} from '../../fixtures/pickers/contentTypes';
+import {assertUtils} from '../../utils/assertUtils';
+import {AccordionItem} from '../../page-object/accordionItem';
+import {JContent} from '../../page-object/jcontent';
+import gql from "graphql-tag";
+
+describe('Picker tests', () => {
+    const siteKey = 'digitall';
+    let jcontent: JContent;
+
+    beforeEach(() => {
+        // I have issues adding these to before()/after() so have to add to beforeEach()/afterEach()
+        cy.login(); // Edit in chief
+        cy.apollo({mutationFile: 'pickers/createCustomContent.graphql'});
+
+        // BeforeEach()
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+    });
+
+    afterEach(() => {
+        cy.apollo({mutation: gql`
+                mutation deleteContent {
+                    jcr {
+                        content: deleteNode(pathOrId: "/sites/digitall/contents/ce-picker-custom-contents")
+                    }
+                }
+            `});
+        cy.logout();
+    });
+
+    // Tests
+
+    it('should refresh picker dialog', () => {
+        const picker = jcontent
+            .createContent(contentTypes.customPicker.typeName)
+            .getPickerField(contentTypes.customPicker.fieldNodeType, contentTypes.customPicker.multiple)
+            .open();
+
+        // Assert components are visible
+        assertUtils.isVisible(picker.get());
+        assertUtils.isVisible(picker.getSiteSwitcher());
+        assertUtils.isVisible(picker.getAccordion());
+
+        cy.log('select a component');
+        const contentAccordion: AccordionItem = picker.getAccordionItem('picker-content-folders');
+        contentAccordion.click().getHeader()
+            .should('be.visible')
+            .and('have.attr', 'aria-expanded')
+            .and('equal', 'true');
+        contentAccordion.getTreeItem('ce-picker-custom-contents').click();
+        contentAccordion.expandTreeItem('ce-picker-custom-contents');
+        picker.getTable().getRowByName('test-loc1').get().should('be.visible').click();
+
+        cy.log('add components in the background');
+        cy.apollo({mutation:gql`
+                mutation addContent {
+                    jcr {
+                        addFolder: mutateNode(pathOrId: "/sites/digitall/contents") {
+                            addChild(name: "refresh1", primaryNodeType: "jnt:contentFolder") {uuid}
+                        }
+                        addContent: mutateNode(pathOrId: "/sites/digitall/contents/ce-picker-custom-contents") {
+                            addChild(name: "refresh2", primaryNodeType: "qant:location", properties: [
+                                { name: "jcr:title", language: "en", value: "refresh2" }
+                            ]) {uuid}
+                        }
+                    }
+                }
+            `});
+
+        cy.log('assert refresh works for nav tree and table and does not change selection on both')
+        picker.getRefreshButton().click();
+        picker.wait();
+        contentAccordion.getTreeItem('ce-picker-custom-contents')
+            .find('div').should('have.class', 'moonstone-selected');
+        contentAccordion.getTreeItem('refresh1').should('be.visible')
+        picker.getTable().getRowByName('refresh2').should('be.visible')
+        picker.getTable().getRowByName('test-loc1')
+            .should('be.visible') // expanded
+            .and('have.class', 'moonstone-TableRow-highlighted') // selected
+
+
+        cy.apollo({mutation: gql`
+                mutation deleteContent {
+                    jcr {folder: deleteNode(pathOrId: "/sites/digitall/contents/refresh1")}
+                }
+            `});
+    });
+
+});

--- a/tests/cypress/page-object/picker.ts
+++ b/tests/cypress/page-object/picker.ts
@@ -5,6 +5,7 @@ import {
     Dropdown,
     getComponent,
     getComponentByAttr,
+    getComponentByRole,
     getComponentBySelector,
     SecondaryNav,
     Table
@@ -41,6 +42,10 @@ export class Picker extends BaseComponent {
 
         // Make sure dialog is open before returning viewMode
         return this && this.viewMode;
+    }
+
+    getRefreshButton() {
+        return getComponentByRole(Button, 'refresh');
     }
 
     getAccordion(): Accordion {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17389

## Description

* Reuse refresh action from jcontent and add to picker targets
* Add cypress test for refresh
