### PR TITLE
BACKLOG-20010: Improve card grid layout

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/FilesGrid/FilesGrid.scss
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/FilesGrid/FilesGrid.scss
@@ -1,39 +1,30 @@
 .grid.grid {
     display: flex;
     flex: 1 1 0;
-    padding: var(--spacing-small);
 
     outline: none;
-    overflow-y: auto;
-    overflow-x: hidden;
-
-    background-color: var(--color-gray_light);
+    overflow: hidden;
 }
 
 .gridEmpty.gridEmpty {
     flex: 1 1 0;
     margin: 0 !important;
-
-    background-color: var(--color-gray_light);
 }
 
 .defaultGrid.defaultGrid {
     display: grid;
     flex: 1;
     gap: var(--spacing-medium);
-    justify-content: start;
-    align-content: start;
-    align-items: start;
-    margin: var(--spacing-small);
 
-    background-color: var(--color-gray_light);
     box-shadow: none;
-    justify-items: stretch;
 }
 
 .detailedGrid.detailedGrid {
-    grid-auto-rows: 360px;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 350px));
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    padding: 0 var(--spacing-medium) var(--spacing-medium);
 }
 
 .empty.empty {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20010

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Change the grid layout to display cards in all the available space as we did for jContent
- Display the same vertical and horizontal gap in the grid
- Add padding-bottom in the grid to avoid having the last row of cards stuck in the pagination, to do that I changed the overflow management.
- Remove the gray background in the thumbnail view