### PR TITLE
BACKLOG-17389: Refactor picker refresh button

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -7,7 +7,7 @@ import {shallowEqual, useSelector} from 'react-redux';
 import {useTranslation} from 'react-i18next';
 import ContentLayout from '~/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout';
 import clsx from 'clsx';
-import {DisplayActions, registry} from '@jahia/ui-extender';
+import {DisplayAction, DisplayActions, registry} from '@jahia/ui-extender';
 import {getButtonRenderer} from '~/utils';
 import {SelectionCaption, SelectionTable} from './PickerSelection';
 import {Search} from './Search';
@@ -46,6 +46,7 @@ const RightPanel = ({pickerConfig, accordionItemProps, onClose, onItemSelection}
                     {mode !== '' && jcontentUtils.booleanValue(pickerConfig.pickerDialog.displaySearch) && <Search pickerConfig={pickerConfig}/>}
                     <div className="flexFluid"/>
                     <DisplayActions target={actionsTarget} render={ButtonRenderer} path={path}/>
+                    <DisplayAction actionKey="refresh" render={ButtonRenderer}/>
                     {viewSelector}
                 </div>
             </header>

--- a/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
+++ b/src/javascript/SelectorTypes/Picker/configs/Picker2.configs.js
@@ -51,13 +51,5 @@ export const registerPickerConfig = registry => {
         registry.get('action', 'pageComposer')?.targets?.push({id: 'content-editor/pickers/picker-pages/header-actions', priority: 1});
         registry.get('action', 'createFolder')?.targets?.push({id: 'content-editor/pickers/picker-media/header-actions', priority: 2});
         registry.get('action', 'fileUpload')?.targets?.push({id: 'content-editor/pickers/picker-media/header-actions', priority: 3});
-        registry.get('action', 'refresh')?.targets?.push({id: 'content-editor/pickers/picker-media/header-actions', priority: 4});
-
-        const refresh = registry.get('action', 'refresh');
-        if (refresh) {
-            Object.values(Constants.ACCORDION_ITEM_TYPES).forEach(type => {
-                refresh.targets.push({id: `content-editor/pickers/picker-${type}/header-actions`, priority: 0});
-            });
-        }
     });
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17389

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Embed refresh button for all pickers instead of dynamically targeting `DisplayActions`
