### PR TITLE
BACKLOG-19873: Add disabled styling for non-selectable items in structured view

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
@@ -30,6 +30,7 @@ import {
 import classes from './ContentTable.scss';
 import {ContextualMenu, registry} from '@jahia/ui-extender';
 import {useFieldContext} from '~/contexts/FieldContext';
+import clsx from 'clsx';
 
 const reduxActions = {
     onPreviewSelectAction: () => ({}),
@@ -208,7 +209,10 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
                                           {...rowProps}
                                           data-cm-role="table-content-list-row"
                                           data-sel-name={node.name}
-                                          className={!selectionProps.checked && className}
+                                          className={clsx({
+                                              [className]: !selectionProps.checked,
+                                              [classes.disabled]: isStructured && !node.isSelectable
+                                          })}
                                           isHighlighted={selectionProps.checked && !field.multiple}
                                           onClick={e => handleOnClick(e, row)}
                                           onContextMenu={event => {

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.scss
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.scss
@@ -5,3 +5,8 @@
 .doubleClickableRow {
     cursor: grab;
 }
+
+.disabled [data-cm-role="table-content-list-cell-name"] [class*="moonstone-IconTextIcon"],
+.disabled [data-cm-role="table-content-list-cell-type"] {
+    color: var(--color-gray60);
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19873

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
