### PR TITLE
BACKLOG-19987: Allow to customize accordions used by a picker

### DIFF
--- a/src/javascript/SelectorTypes/Picker/Picker2.jsx
+++ b/src/javascript/SelectorTypes/Picker/Picker2.jsx
@@ -138,7 +138,7 @@ export const Picker2 = ({field, value, editorContext, inputContext, onChange, on
                     editorContext={editorContext}
                     pickerConfig={pickerConfig}
                     initialSelectedItem={fieldData && fieldData.map(f => f.path)}
-                    accordionItemProps={parsedOptions.accordionItem === undefined ? pickerConfig.accordionItem : parsedOptions.accordionItem}
+                    accordionItemProps={mergeDeep({}, pickerConfig.accordionItem, parsedOptions.accordionItem)}
                     onClose={() => setDialogOpen(false)}
                     onItemSelection={onItemSelection}
                 />

--- a/src/javascript/SelectorTypes/Picker/Picker2.jsx
+++ b/src/javascript/SelectorTypes/Picker/Picker2.jsx
@@ -138,7 +138,7 @@ export const Picker2 = ({field, value, editorContext, inputContext, onChange, on
                     editorContext={editorContext}
                     pickerConfig={pickerConfig}
                     initialSelectedItem={fieldData && fieldData.map(f => f.path)}
-                    accordionItemProps={parsedOptions.accordionItem}
+                    accordionItemProps={parsedOptions.accordionItem === undefined ? pickerConfig.accordionItem : parsedOptions.accordionItem}
                     onClose={() => setDialogOpen(false)}
                     onItemSelection={onItemSelection}
                 />

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
@@ -11,6 +11,7 @@ import clsx from 'clsx';
 import styles from './ContentLayout.scss';
 import {cePickerOpenPaths} from '~/SelectorTypes/Picker/Picker2.redux';
 import FilesGrid from '~/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/FilesGrid';
+import PropTypes from 'prop-types';
 
 const setRefetcher = (name, refetcherData) => {
     registry.addOrReplace('refetcher', name, refetcherData);
@@ -28,7 +29,7 @@ const getFilesMode = (state, pickerConfig) => {
     return state.contenteditor.picker.fileView.mode;
 };
 
-export const ContentLayoutContainer = ({pickerConfig}) => {
+export const ContentLayoutContainer = ({pickerConfig, accordionItemProps}) => {
     const {t} = useTranslation();
     const currentResult = useRef();
     const {mode, path, filesMode, preSearchModeMemo, viewType} = useSelector(state => ({
@@ -129,19 +130,21 @@ export const ContentLayoutContainer = ({pickerConfig}) => {
                 </div>
             )}
             {(mode === Constants.mode.MEDIA || preSearchModeMemo === Constants.mode.MEDIA) && filesMode === Constants.fileView.mode.THUMBNAILS ?
-                (<FilesGrid rows={rows} totalCount={totalCount} isLoading={loading}/>) :
+                (<FilesGrid rows={rows} totalCount={totalCount} isLoading={loading} accordionItemProps={accordionItemProps}/>) :
                 (<ContentTable path={path}
                                rows={rows}
                                isStructured={isStructured}
                                isLoading={loading}
                                totalCount={totalCount}
+                               accordionItemProps={accordionItemProps}
                 />)}
         </div>
     );
 };
 
 ContentLayoutContainer.propTypes = {
-    pickerConfig: configPropType.isRequired
+    pickerConfig: configPropType.isRequired,
+    accordionItemProps: PropTypes.object
 };
 
 export default ContentLayoutContainer;

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
@@ -31,6 +31,7 @@ import classes from './ContentTable.scss';
 import {ContextualMenu, registry} from '@jahia/ui-extender';
 import {useFieldContext} from '~/contexts/FieldContext';
 import clsx from 'clsx';
+import {jcontentUtils} from '@jahia/jcontent';
 
 const reduxActions = {
     onPreviewSelectAction: () => ({}),
@@ -61,7 +62,7 @@ const SELECTION_COLUMN_ID = 'selection';
 
 const defaultCols = ['publicationStatus', 'name', 'type', 'lastModified'];
 
-export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, isStructured}) => {
+export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, isStructured, accordionItemProps}) => {
     const {t} = useTranslation();
     const field = useFieldContext();
     const dispatch = useDispatch();
@@ -83,9 +84,12 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
     };
 
     const previousMode = mode === Constants.mode.SEARCH ? preSearchModeMemo : mode;
-    const previousModeTableConfig = registry.get('accordionItem', previousMode)?.tableConfig;
-    const tableConfig = registry.get('accordionItem', mode)?.tableConfig;
-
+    const previousModeTableConfig = useMemo(() => {
+        return jcontentUtils.getAccordionItem(registry.get('accordionItem', previousMode), accordionItemProps)?.tableConfig;
+    }, [previousMode, accordionItemProps]);
+    const tableConfig = useMemo(() => {
+        return jcontentUtils.getAccordionItem(registry.get('accordionItem', mode), accordionItemProps)?.tableConfig;
+    }, [mode, accordionItemProps]);
     const columns = useMemo(() => {
         const flattenRows = isStructured ? flattenTree(rows) : rows;
         const colNames = previousModeTableConfig?.columns || defaultCols;
@@ -256,7 +260,8 @@ ContentTable.propTypes = {
     isLoading: PropTypes.bool,
     isStructured: PropTypes.bool,
     rows: PropTypes.array.isRequired,
-    totalCount: PropTypes.number.isRequired
+    totalCount: PropTypes.number.isRequired,
+    accordionItemProps: PropTypes.object
 };
 
 export default ContentTable;

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/FilesGrid/FilesGrid.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/FilesGrid/FilesGrid.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {FileCard, UploadTransformComponent, FilesGridEmptyDropZone} from '@jahia/jcontent';
@@ -20,6 +20,7 @@ import {getDetailedPathArray} from '~/SelectorTypes/Picker/Picker2.utils';
 import {batchActions} from 'redux-batched-actions';
 import {useFieldContext} from '~/contexts/FieldContext';
 import {registry} from '@jahia/ui-extender';
+import {jcontentUtils} from '@jahia/jcontent';
 
 const reduxActions = {
     setOpenPathAction: path => cePickerOpenPaths(getDetailedPathArray(path)),
@@ -32,7 +33,7 @@ const reduxActions = {
     clearSelection: () => cePickerClearSelection()
 };
 
-export const FilesGrid = ({totalCount, rows, isLoading}) => {
+export const FilesGrid = ({totalCount, rows, isLoading, accordionItemProps}) => {
     const {t} = useTranslation('jcontent');
     const {mode, pickerKey, path, pagination, siteKey, uilang, lang, selection} = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
@@ -46,6 +47,9 @@ export const FilesGrid = ({totalCount, rows, isLoading}) => {
     }), shallowEqual);
     const dispatch = useDispatch();
     const field = useFieldContext();
+    const tableConfig = useMemo(() => {
+        return jcontentUtils.getAccordionItem(registry.get('accordionItem', mode), accordionItemProps)?.tableConfig;
+    }, [mode, accordionItemProps]);
     const onPreviewSelect = previewSelection => {
         const node = rows.find(value => value.path === previewSelection);
         const actions = [];
@@ -76,8 +80,6 @@ export const FilesGrid = ({totalCount, rows, isLoading}) => {
             </React.Fragment>
         );
     }
-
-    const tableConfig = registry.get('accordionItem', mode)?.tableConfig;
 
     return (
         <>
@@ -128,7 +130,8 @@ export const FilesGrid = ({totalCount, rows, isLoading}) => {
 FilesGrid.propTypes = {
     isLoading: PropTypes.bool.isRequired,
     rows: PropTypes.array.isRequired,
-    totalCount: PropTypes.number.isRequired
+    totalCount: PropTypes.number.isRequired,
+    accordionItemProps: PropTypes.object
 };
 
 export default FilesGrid;

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -54,7 +54,7 @@ const RightPanel = ({pickerConfig, accordionItemProps, onClose, onItemSelection}
                 {mode !== '' && <ContentLayout pickerConfig={pickerConfig} accordionItemProps={accordionItemProps}/>}
             </div>
 
-            <SelectionTable selection={selection} expanded={selectionExpanded} pickerConfig={pickerConfig} accordionItemProps={accordionItemProps}/>
+            <SelectionTable selection={selection} expanded={selectionExpanded} pickerConfig={pickerConfig}/>
             <footer className={clsx('flexRow', 'alignCenter', css.footer)}>
                 <SelectionCaption selection={selection} pickerConfig={pickerConfig} expanded={selectionExpanded}/>
                 <div className={clsx('flexRow', css.actions)}>

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -51,10 +51,10 @@ const RightPanel = ({pickerConfig, accordionItemProps, onClose, onItemSelection}
                 </div>
             </header>
             <div className={clsx('flexFluid', 'flexCol_nowrap', css.body)}>
-                {mode !== '' && <ContentLayout pickerConfig={pickerConfig}/>}
+                {mode !== '' && <ContentLayout pickerConfig={pickerConfig} accordionItemProps={accordionItemProps}/>}
             </div>
 
-            <SelectionTable selection={selection} expanded={selectionExpanded} pickerConfig={pickerConfig}/>
+            <SelectionTable selection={selection} expanded={selectionExpanded} pickerConfig={pickerConfig} accordionItemProps={accordionItemProps}/>
             <footer className={clsx('flexRow', 'alignCenter', css.footer)}>
                 <SelectionCaption selection={selection} pickerConfig={pickerConfig} expanded={selectionExpanded}/>
                 <div className={clsx('flexRow', css.actions)}>

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
@@ -89,15 +89,6 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
 
         let allAccordionItems = jcontentUtils.getAccordionItems(pickerConfig.key, accordionItemProps);
 
-        if (allAccordionItems.length === 0 && pickerConfig.accordions !== undefined && pickerConfig.accordions.length > 0) {
-            allAccordionItems = [];
-            pickerConfig.accordions.forEach(value => {
-                const accordionItem = registry.get('accordionItem', value);
-                accordionItem.targets.push({id: pickerConfig.key, priority: 50});
-                allAccordionItems.push(jcontentUtils.getAccordionItem(accordionItem, accordionItemProps));
-            });
-        }
-
         let firstMatchingAccordion = allAccordionItems.find(accord =>
             (!accord.isEnabled || accord.isEnabled(newState.site)) &&
             accord.canDisplayItem &&

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
@@ -87,7 +87,7 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
 
         const selectedNode = nodesInfo.data && nodesInfo.data.jcr.nodesByPath.length > 0 && nodesInfo.data.jcr.nodesByPath[0];
 
-        let allAccordionItems = jcontentUtils.getAccordionItems(pickerConfig.key, accordionItemProps);
+        const allAccordionItems = jcontentUtils.getAccordionItems(pickerConfig.key, accordionItemProps);
 
         let firstMatchingAccordion = allAccordionItems.find(accord =>
             (!accord.isEnabled || accord.isEnabled(newState.site)) &&

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
@@ -87,7 +87,16 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
 
         const selectedNode = nodesInfo.data && nodesInfo.data.jcr.nodesByPath.length > 0 && nodesInfo.data.jcr.nodesByPath[0];
 
-        const allAccordionItems = jcontentUtils.getAccordionItems(pickerConfig.key, accordionItemProps);
+        let allAccordionItems = jcontentUtils.getAccordionItems(pickerConfig.key, accordionItemProps);
+
+        if (allAccordionItems.length === 0 && pickerConfig.accordions !== undefined && pickerConfig.accordions.length > 0) {
+            allAccordionItems = [];
+            pickerConfig.accordions.forEach(value => {
+                const accordionItem = registry.get('accordionItem', value);
+                accordionItem.targets.push({id: pickerConfig.key, priority: 50});
+                allAccordionItems.push(jcontentUtils.getAccordionItem(accordionItem, accordionItemProps));
+            });
+        }
 
         let firstMatchingAccordion = allAccordionItems.find(accord =>
             (!accord.isEnabled || accord.isEnabled(newState.site)) &&

--- a/src/javascript/SelectorTypes/Picker/actions/registerPickerActions.js
+++ b/src/javascript/SelectorTypes/Picker/actions/registerPickerActions.js
@@ -52,20 +52,4 @@ export const registerPickerActions = registry => {
         contentType: 'jnt:file',
         dataSelRole: 'upload'
     });
-
-    setTimeout(() => {
-        registry.add('action', 'contentPickerMenu', registry.get('action', 'menuAction'), {
-            buttonIcon: <MoreVert/>,
-            buttonLabel: 'jcontent:label.contentManager.contentPreview.moreOptions',
-            menuTarget: 'contentPickerActions',
-            menuItemProps: {
-                isShowIcons: true
-            }
-        });
-
-        registry.get('action', 'rename')?.targets?.push({id: 'contentPickerActions', priority: 1});
-        registry.get('action', 'replaceFile')?.targets?.push({id: 'contentPickerActions', priority: 2});
-        registry.get('action', 'editImage')?.targets?.push({id: 'contentPickerActions', priority: 3});
-        registry.get('action', 'openInNewTab')?.targets?.push({id: 'contentPickerActions', priority: 4});
-    });
 };

--- a/src/javascript/init.js
+++ b/src/javascript/init.js
@@ -1,9 +1,39 @@
 import {registry} from '@jahia/ui-extender';
 import {register} from './register';
+import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
+import {MoreVert} from '@jahia/moonstone';
+import React from 'react';
 
 export default function () {
     registry.add('callback', 'content-editor', {
         targets: ['jahiaApp-init:2'],
         callback: register
+    });
+
+    registry.add('callback', 'updateAccordionTargetsFromPickerConfigurations', {
+        targets: ['jahiaApp-init:999'],
+        callback: () => {
+            const registeredPickerConfigurations = registry.find({type: Constants.pickerConfig});
+            registeredPickerConfigurations.forEach(pickerConfig => {
+                pickerConfig.accordions?.forEach(value => {
+                    const accordionItem = registry.get('accordionItem', value);
+                    accordionItem.targets.push({id: pickerConfig.key, priority: 50});
+                });
+            });
+            // Update actions targets
+            registry.add('action', 'contentPickerMenu', registry.get('action', 'menuAction'), {
+                buttonIcon: <MoreVert/>,
+                buttonLabel: 'jcontent:label.contentManager.contentPreview.moreOptions',
+                menuTarget: 'contentPickerActions',
+                menuItemProps: {
+                    isShowIcons: true
+                }
+            });
+
+            registry.get('action', 'rename')?.targets?.push({id: 'contentPickerActions', priority: 1});
+            registry.get('action', 'replaceFile')?.targets?.push({id: 'contentPickerActions', priority: 2});
+            registry.get('action', 'editImage')?.targets?.push({id: 'contentPickerActions', priority: 3});
+            registry.get('action', 'openInNewTab')?.targets?.push({id: 'contentPickerActions', priority: 4});
+        }
     });
 }


### PR DESCRIPTION
…

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19987

## Description

Allow to customize accordions used by a picker directly from the picker. Allow to pass accordionItemsProps directly from the picker config

https://docs.google.com/document/d/1WyI_EMJA9K6r6NYJzC7ZJiE-yCJBuMcITGrBW-vf5IE/edit#
