### PR TITLE
BACKLOG-19961: Add default pickers by type constraint

### DIFF
--- a/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog2.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog2.jsx
@@ -60,6 +60,7 @@ export const PickerDialog = ({
             fullWidth
             maxWidth="xl"
             data-sel-role="picker-dialog"
+            data-sel-type={pickerConfig.key}
             classes={{paper: styles.paper}}
             open={isOpen}
             TransitionComponent={Transition}

--- a/src/javascript/SelectorTypes/Picker/registerPicker.js
+++ b/src/javascript/SelectorTypes/Picker/registerPicker.js
@@ -14,7 +14,7 @@ import {Constants} from '~/SelectorTypes/Picker/Picker2.constants';
  */
 const inferPickerConfig = (registry, field) => {
     const pickerConfigs = registry.find({type: Constants.pickerConfig});
-    const constraints = field.valueConstraints.map(c => c.displayValue) || [];
+    const constraints = field.valueConstraints?.map(c => c.displayValue) || [];
     const pickerConfig = pickerConfigs.find(config => {
         const selectorTypes = config.selectableTypesTable;
         // Check if selectorTypes matches field constraints

--- a/src/javascript/SelectorTypes/resolveSelectorType.js
+++ b/src/javascript/SelectorTypes/resolveSelectorType.js
@@ -4,7 +4,7 @@ export const resolveSelectorType = ({selectorType, selectorOptions, displayName,
     let selector = registry.get('selectorType', selectorType);
     if (selector) {
         if (selector.resolver) {
-            return selector.resolver(selectorOptions);
+            return selector.resolver(selectorOptions, field);
         }
 
         return selector;

--- a/tests/cypress/e2e/pickers/pickerDefaults.cy.ts
+++ b/tests/cypress/e2e/pickers/pickerDefaults.cy.ts
@@ -1,0 +1,151 @@
+import {contentTypes} from '../../fixtures/pickers/contentTypes';
+import {JContent} from '../../page-object/jcontent';
+
+describe('Picker default tests', () => {
+    const siteKey = 'digitall';
+    let jcontent: JContent;
+
+    beforeEach(() => {
+        // I have issues adding these to before()/after() so have to add to beforeEach()/afterEach()
+        cy.login(); // Edit in chief
+
+        // BeforeEach()
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+    });
+
+    afterEach(() => {
+        cy.logout();
+    });
+
+    // Tests
+
+    it('should open default page picker', () => {
+        const contentType = contentTypes.pageDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'page');
+    });
+
+    it('should open default contentfolder picker', () => {
+        const contentType = contentTypes.contentfolderDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'contentfolder');
+    });
+
+    it('should open default folder picker', () => {
+        const contentType = contentTypes.folderDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'folder');
+    });
+
+    it('should open default file picker', () => {
+        const contentType = contentTypes.fileDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'file');
+    });
+
+    it('should open default image picker', () => {
+        const contentType = contentTypes.imageDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'image');
+    });
+
+    it('should open default editoriallink picker', () => {
+        const contentType = contentTypes.editoriallinkDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'editoriallink');
+    });
+
+    it('should open default user picker', () => {
+        const contentType = contentTypes.userDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'user');
+    });
+
+    it('should open default usergroup picker', () => {
+        const contentType = contentTypes.usergroupDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'usergroup');
+    });
+
+    it('should open default site picker', () => {
+        const contentType = contentTypes.siteDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'site');
+    });
+
+    it('should open default category picker', () => {
+        const contentType = contentTypes.categoryDefault;
+        const picker = jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        // Assert we have the right picker config type
+        picker.get()
+            .should('be.visible')
+            .and('have.attr', 'data-sel-type', 'category');
+    });
+});

--- a/tests/cypress/fixtures/pickers/contentTypes.ts
+++ b/tests/cypress/fixtures/pickers/contentTypes.ts
@@ -148,6 +148,56 @@ const contentTypes: ContentTypes = {
         typeName: 'customPicker',
         fieldNodeType: 'qant:customPicker_myAdress',
         multiple: false
+    },
+    pageDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_page',
+        multiple: false
+    },
+    contentfolderDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_contentFolder',
+        multiple: false
+    },
+    folderDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_folder',
+        multiple: false
+    },
+    fileDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_file',
+        multiple: false
+    },
+    imageDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_image',
+        multiple: false
+    },
+    editoriallinkDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_editoriallink',
+        multiple: false
+    },
+    userDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_user',
+        multiple: false
+    },
+    usergroupDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_usergroup',
+        multiple: false
+    },
+    siteDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_site',
+        multiple: false
+    },
+    categoryDefault: {
+        typeName: 'pickersDefault',
+        fieldNodeType: 'qant:pickersDefault_category',
+        multiple: false
     }
 };
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19961

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

 * Add default pickers based from CND type constraints by matching `selectableTypesTable` attribute in the picker config
 * Add cypress test 