### PR TITLE
BACKLOG-20101: Add page-type filter for content view

### DIFF
--- a/src/javascript/SelectorTypes/Picker/configs/editorialPicker/PickerPagesQueryHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialPicker/PickerPagesQueryHandler.jsx
@@ -17,14 +17,21 @@ export const PickerPagesQueryHandler = {
         }
     },
 
-    getQueryVariables: options => ({
-        ...PagesQueryHandler.getQueryVariables(options),
-        selectableTypesTable: options.selectableTypesTable,
-        typeFilter: options.selectableTypesTable.includes('jnt:page') && Constants.tableView.type.PAGES === options.tableView.viewType ? ['jnt:page'] : options.selectableTypesTable.filter(t => t !== 'jnt:page'),
-        fieldFilter: {
-            multi: options.tableDisplayFilter ? 'ANY' : 'NONE',
-            filters: (options.tableDisplayFilter ? options.tableDisplayFilter : [])
-        }
-    }),
+    getQueryVariables: options => {
+        const {selectableTypesTable, tableDisplayFilter} = options;
+        const isPagesViewType = Constants.tableView.type.PAGES === options.tableView.viewType;
+        const isPageTypeFn = t => t === 'jnt:page' || t === 'jmix:navMenuItem';
+        let typeFilter = isPagesViewType ? selectableTypesTable.filter(isPageTypeFn) : selectableTypesTable.filter(t => !isPageTypeFn(t));
+
+        return {
+            ...PagesQueryHandler.getQueryVariables(options),
+            selectableTypesTable,
+            typeFilter,
+            fieldFilter: {
+                multi: tableDisplayFilter ? 'ANY' : 'NONE',
+                filters: tableDisplayFilter || []
+            }
+        };
+    },
     getFragments: () => [...PagesQueryHandler.getFragments(), selectableTypeFragment]
 };

--- a/tests/cypress/e2e/pickers/site.cy.ts
+++ b/tests/cypress/e2e/pickers/site.cy.ts
@@ -54,6 +54,8 @@ describe('Picker - Site', () => {
 
         picker.getTable().selectItems(3);
         picker.select();
+
+        contentEditor.getPickerField('qant:pickersMultiple_sitepicker', true).get().scrollIntoView();
         pickerField.assertValue('Digitall');
         pickerField.assertValue('site1');
         pickerField.assertValue('site2');


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20101

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

It looks like including `jmix:navMenuItem` to typeFilter also returns `jnt:page` in the results.

Filter out page-like node types when view type is not pages