### PR TITLE
BACKLOG-17144: avoid calling onChange if previousValue and currentValue are the same

### DIFF
--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
@@ -56,7 +56,7 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
     }, [editorContext, sectionsContext, formik, client]);
 
     const registeredOnChange = useCallback(currentValue => {
-        if (registeredOnChanges && registeredOnChanges.length > 0) {
+        if (registeredOnChanges && registeredOnChanges.length > 0 && onChangeValue.current !== currentValue) {
             registeredOnChanges.forEach(currentOnChange => {
                 if (currentOnChange.onChange) {
                     try {

--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.spec.jsx
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.spec.jsx
@@ -139,14 +139,14 @@ describe('Field component', () => {
 
         // Should init call the onChange
         cmp.debug();
-        expect(result[0]).toBe(onChangePreviousValue);
+        expect(result[0]).toBe(undefined);
         expect(result[1]).toBe(onChangePreviousValue);
         expect(formik.setFieldValue).not.toHaveBeenCalled();
         expect(formik.setFieldTouched).not.toHaveBeenCalled();
 
         // Trigger field update
         cmp.find('SingleField').props().onChange(onChangeCurrentValue);
-        expect(result[0]).toBe(undefined);
+        expect(result[0]).toBe(onChangePreviousValue);
         expect(result[1]).toBe(onChangeCurrentValue);
         expect(formik.setFieldValue).toHaveBeenCalledWith('text', onChangeCurrentValue);
     });

--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.spec.jsx
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.spec.jsx
@@ -146,7 +146,7 @@ describe('Field component', () => {
 
         // Trigger field update
         cmp.find('SingleField').props().onChange(onChangeCurrentValue);
-        expect(result[0]).toBe(onChangePreviousValue);
+        expect(result[0]).toBe(undefined);
         expect(result[1]).toBe(onChangeCurrentValue);
         expect(formik.setFieldValue).toHaveBeenCalledWith('text', onChangeCurrentValue);
     });


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17144


