### PR TITLE
BACKLOG-20085 - Revert release and update module dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>content-editor</artifactId>
     <name>Jahia Content Editor</name>
-    <version>4.1.0</version>
+    <version>4.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Jahia Content Editor React extension.</description>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:git@github.com:Jahia/content-editor.git</connection>
         <developerConnection>scm:git:git@github.com:Jahia/content-editor.git</developerConnection>
         <url>https://github.com/Jahia/content-editor</url>
-        <tag>4_1_0</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <jahia-module-type>system</jahia-module-type>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>content-editor</artifactId>
     <name>Jahia Content Editor</name>
-    <version>4.2.0-SNAPSHOT</version>
+    <version>4.1.0</version>
     <packaging>bundle</packaging>
     <description>Jahia Content Editor React extension.</description>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:git@github.com:Jahia/content-editor.git</connection>
         <developerConnection>scm:git:git@github.com:Jahia/content-editor.git</developerConnection>
         <url>https://github.com/Jahia/content-editor</url>
-        <tag>HEAD</tag>
+        <tag>4_1_0</tag>
     </scm>
     <properties>
         <jahia-module-type>system</jahia-module-type>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.1.0</version>
+        <version>8.1.0.0</version>
         <relativePath />
     </parent>
     <artifactId>content-editor</artifactId>
@@ -49,7 +49,7 @@
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-module-signature>MCwCFB5+Fa/WHCbtVxxuKu0Af4ZF0gUjAhR22ZoFtOrFzNhcvgVlpKZvAcS2Tw==</jahia-module-signature>
-        <jahia-depends>app-shell=2.7,graphql-dxm-provider=2.13,jcontent=2.8</jahia-depends>
+        <jahia-depends>app-shell=(2.6,3),graphql-dxm-provider=2.13,jcontent=(2.7,3)</jahia-depends>
         <import-package>
             com.fasterxml.jackson.annotation;version="[2.10,3)",
             com.fasterxml.jackson.databind;version="[2.10,3)",

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-module-signature>MCwCFB5+Fa/WHCbtVxxuKu0Af4ZF0gUjAhR22ZoFtOrFzNhcvgVlpKZvAcS2Tw==</jahia-module-signature>
-        <jahia-depends>jcontent=[2.8,3)</jahia-depends>
+        <jahia-depends>app-shell=2.7,graphql-dxm-provider=2.13,jcontent=2.8</jahia-depends>
         <import-package>
             com.fasterxml.jackson.annotation;version="[2.10,3)",
             com.fasterxml.jackson.databind;version="[2.10,3)",

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.0.0</version>
+        <version>8.1.1.0</version>
         <relativePath />
     </parent>
     <artifactId>content-editor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-        <jahia-module-signature>MCwCFGhPz7X+MNP7sw0OzaKrhYdyYC8rAhRBNrXwEWOy1RArpsP/IxuMhhF9Ig==</jahia-module-signature>
+        <jahia-module-signature>MCwCFB5+Fa/WHCbtVxxuKu0Af4ZF0gUjAhR22ZoFtOrFzNhcvgVlpKZvAcS2Tw==</jahia-module-signature>
         <jahia-depends>jcontent=[2.8,3)</jahia-depends>
         <import-package>
             com.fasterxml.jackson.annotation;version="[2.10,3)",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20085

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Revert the 4.1.0 release and update the module dependencies to make it clear we need:

- app-shell=2.7+
- graphql-dxm-provider=2.13+
- jcontent=2.8+