### PR TITLE
BACKLOG-20085: revert fix test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>content-editor</artifactId>
     <name>Jahia Content Editor</name>
-    <version>4.1.0</version>
+    <version>4.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Jahia Content Editor React extension.</description>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:git@github.com:Jahia/content-editor.git</connection>
         <developerConnection>scm:git:git@github.com:Jahia/content-editor.git</developerConnection>
         <url>https://github.com/Jahia/content-editor</url>
-        <tag>4_1_0</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <jahia-module-type>system</jahia-module-type>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>content-editor</artifactId>
     <name>Jahia Content Editor</name>
-    <version>4.2.0-SNAPSHOT</version>
+    <version>4.1.0</version>
     <packaging>bundle</packaging>
     <description>Jahia Content Editor React extension.</description>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:git@github.com:Jahia/content-editor.git</connection>
         <developerConnection>scm:git:git@github.com:Jahia/content-editor.git</developerConnection>
         <url>https://github.com/Jahia/content-editor</url>
-        <tag>HEAD</tag>
+        <tag>4_1_0</tag>
     </scm>
     <properties>
         <jahia-module-type>system</jahia-module-type>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-module-signature>MCwCFB5+Fa/WHCbtVxxuKu0Af4ZF0gUjAhR22ZoFtOrFzNhcvgVlpKZvAcS2Tw==</jahia-module-signature>
-        <jahia-depends>jcontent=[2.8,3)</jahia-depends>
+        <jahia-depends>app-shell=2.7,graphql-dxm-provider=2.13,jcontent=2.8</jahia-depends>
         <import-package>
             com.fasterxml.jackson.annotation;version="[2.10,3)",
             com.fasterxml.jackson.databind;version="[2.10,3)",

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.0.0</version>
+        <version>8.1.1.0</version>
         <relativePath />
     </parent>
     <artifactId>content-editor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-        <jahia-module-signature>MCwCFGhPz7X+MNP7sw0OzaKrhYdyYC8rAhRBNrXwEWOy1RArpsP/IxuMhhF9Ig==</jahia-module-signature>
+        <jahia-module-signature>MCwCFB5+Fa/WHCbtVxxuKu0Af4ZF0gUjAhR22ZoFtOrFzNhcvgVlpKZvAcS2Tw==</jahia-module-signature>
         <jahia-depends>jcontent=[2.8,3)</jahia-depends>
         <import-package>
             com.fasterxml.jackson.annotation;version="[2.10,3)",

--- a/src/test/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImplTest.java
+++ b/src/test/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImplTest.java
@@ -270,13 +270,16 @@ public class EditorFormServiceImplTest extends AbstractJUnitTest {
     @Test
     public void testHasPreviewOverride() throws Exception {
         // ** Test on folder.
+        EditorForm form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, folderNode.getPath());
+        int numSections = form.getSections().size();
+
         // Add base + override of folder
         staticDefinitionsRegistry.readEditorFormDefinition(getResource("META-INF/jahia-content-editor-forms/overrides/forms/nt_base.json"), new DummyBundle(0));
         staticDefinitionsRegistry.readEditorFormDefinition(getResource("META-INF/jahia-content-editor-forms/overrides/forms/jnt_folder.json"), new DummyBundle(0));
 
-        EditorForm form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, folderNode.getPath());
+        form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, folderNode.getPath());
         Assert.isTrue(!form.hasPreview(), "Override of folder should NOT have preview");
-        Assert.isTrue(form.getSections() != null && form.getSections().size() == 1, "Override should NOT have change sections");
+        Assert.isTrue(form.getSections() != null && form.getSections().size() == numSections, "Override should NOT have change sections");
 
         // ** Test on text
         // Check default behaviour of text
@@ -314,8 +317,9 @@ public class EditorFormServiceImplTest extends AbstractJUnitTest {
         staticDefinitionsRegistry.readEditorFormDefinition(getResource("META-INF/jahia-content-editor-forms/overrides/forms/nt_base.json"), new DummyBundle(0));
 
         EditorForm form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
-        Assert.isTrue(form.getSections().size() == 1, "Override contains more than one section");
-        Assert.isTrue(form.getSections().get(0).getName().equals("layout"), "Override does not contains \"layout\" section");
+        Assert.isTrue(form.getSections().size() == 5, "Override contains more than one section");
+        EditorFormSection section = form.getSections().stream().filter(s -> s.getName().equals("layout")).findFirst().orElse(null);
+        Assert.isNotNull(section, "Override does not contains \"layout\" section");
     }
 
     @Test
@@ -324,21 +328,35 @@ public class EditorFormServiceImplTest extends AbstractJUnitTest {
         // check the override
         staticDefinitionsRegistry.readEditorFormDefinition(getResource("META-INF/jahia-content-editor-forms/overrides/forms/nt_base.json"), new DummyBundle(0));
         EditorForm form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
-        Assert.isTrue(form.getSections().size() == 1, "Priority check on section does not contain 1 section");
-        Assert.isTrue(form.getSections().get(0).getName().equals("layout"), "Priority check on section does not contain options then content");
+        int initNumSections = 5;
+        Assert.isTrue(form.getSections().size() == initNumSections, "Priority check on section does not contain 1 section");
+        EditorFormSection section = form.getSections().stream().filter(s -> s.getName().equals("layout")).findFirst().orElse(null);
+        Assert.isNotNull(section, "Priority check on section does not contain options then content");
 
         // inject same priority / nodeType => should not change anything
         staticDefinitionsRegistry.readEditorFormDefinition(getResource("META-INF/jahia-content-editor-forms/overrides/forms/nt_base.same-priority.json"), new DummyBundle(0));
         form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
-        Assert.isTrue(form.getSections().size() == 1, "Same priority should not taken in account : Priority check on section does not contain 1 section");
-        Assert.isTrue(form.getSections().get(0).getName().equals("layout"), "Same priority should not taken in account : Priority check on section does not contain options then content");
+        Assert.isTrue(form.getSections().size() == initNumSections,
+            "Same priority should not taken in account : Priority check on section does not contain 1 section");
+        section = form.getSections().stream().filter(s -> s.getName().equals("layout")).findFirst().orElse(null);
+        Assert.isNotNull(section, "Same priority should not taken in account : Priority check on section does not contain options then content");
 
         // Inject higher priority
         staticDefinitionsRegistry.readEditorFormDefinition(getResource("META-INF/jahia-content-editor-forms/overrides/forms/nt_base.priority.json"), new DummyBundle(0));
         form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
-        Assert.isTrue(form.getSections().size() == 2, "Priority check on section does not contain 2 sections");
-        Assert.isTrue(form.getSections().get(0).getName().equals("options") && form.getSections().get(1).getName().equals("content"), "Priority check on section does not contain options then content");
+        Assert.isTrue(form.getSections().size() == initNumSections, "Priority check on section does not contain 2 sections");
 
+        boolean hasOptions = false;
+        boolean hasContent = false;
+        for (EditorFormSection s :form.getSections()) {
+            if (s.getName().equals("options")) {
+                hasOptions = true;
+            } else if (s.getName().equals("content")) {
+                hasContent = true;
+                Assert.isTrue(hasOptions, "Priority check on section does not contain options then content");
+            }
+        }
+        Assert.isTrue(hasOptions && hasContent);
     }
 
     @Test
@@ -348,8 +366,9 @@ public class EditorFormServiceImplTest extends AbstractJUnitTest {
             getResource("META-INF/jahia-content-editor-forms/overrides/forms/jnt_text.json"), new DummyBundle(0));
 
         EditorForm form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
-        Assert.isTrue(form.getSections().size() == 1, "Override contains more than one section");
-        Assert.isTrue(form.getSections().get(0).getName().equals("metadata"), "Override does not contains \"metadata\" section");
+        Assert.isTrue(form.getSections().size() == 5, "Override contains more than one section");
+        EditorFormSection section = form.getSections().stream().filter(s -> s.getName().equals("metadata")).findFirst().orElse(null);
+        Assert.isNotNull(section, "Override does not contains \"metadata\" section");
     }
 
     @Test
@@ -438,31 +457,34 @@ public class EditorFormServiceImplTest extends AbstractJUnitTest {
             .readEditorFormDefinition(getResource("META-INF/jahia-content-editor-forms/overrides/forms/nt_base.json"), new DummyBundle(0));
 
         EditorForm form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
-        Assert.isTrue(form.getSections().size() == 1, "Check on section does not contain 1 section");
-        Assert.isTrue(form.getSections().get(0).getName().equals("layout"), "Check on section does not contain layout section");
-        Assert.isTrue(!form.getSections().get(0).isHide(), "Section should not be hidden");
+        int numSections = form.getSections().size();
+        EditorFormSection section = form.getSections().stream().filter(s -> s.getName().equals("layout")).findFirst().orElse(null);
+        Assert.isNotNull(section, "Check on section does not contain layout section");
+        Assert.isTrue(!section.isHide(), "Section should not be hidden");
 
         SortedSet<EditorFormDefinition> formDefinitions = staticDefinitionsRegistry.getFormDefinitions("nt:base");
-        Assert.isTrue(formDefinitions.size() == 1, "Number of form definition is not correct");
+        int numDefinitions = 2; // we have nt:base definitions from /api and /test
+        Assert.isTrue(formDefinitions.size() == numDefinitions, "Number of form definition is not correct");
 
         // inject same file from another bundle => should be added
         staticDefinitionsRegistry
             .readEditorFormDefinition(getResource("META-INF/jahia-content-editor-forms/overrides/forms/nt_base.json"), new DummyBundle(1));
         form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
-        Assert.isTrue(formDefinitions.size() == 2, "Number of form definition is not correct");
-        Assert.isTrue(form.getSections().size() == 1, "Should contain only 1 section");
+        Assert.isTrue(formDefinitions.size() == numDefinitions + 1, "Number of form definition is not correct");
+        Assert.isTrue(form.getSections().size() == numSections, "Should have same number of sections");
 
         // inject another file from another bundle => should be added
         staticDefinitionsRegistry
             .readEditorFormDefinition(getResource("META-INF/jahia-content-editor-forms/overrides/forms/nt_base.hidden-layout.json"),
                 new DummyBundle(1));
         form = editorFormService.getEditForm(Locale.ENGLISH, Locale.ENGLISH, textNode.getPath());
-        Assert.isTrue(formDefinitions.size() == 3, "Number of form definition is not correct");
-        Assert.isTrue(form.getSections().size() == 1, "Should contain 1 section");
-        Assert.isTrue(form.getSections().get(0).isHide(), "Section should be hidden");
+        Assert.isTrue(formDefinitions.size() == numDefinitions + 1, "Number of form definition is not correct");
+        Assert.isTrue(form.getSections().size() == numSections, "Should have same number of sections");
+        section = form.getSections().stream().filter(s -> s.getName().equals("layout")).findFirst().orElse(null);
+        Assert.isTrue(section.isHide(), "Section should be hidden"); // failing
 
         formDefinitions = staticDefinitionsRegistry.getFormDefinitions("nt:base");
-        Assert.isTrue(formDefinitions.size() == 3, "Number of form definition is not correct");
+        Assert.isTrue(formDefinitions.size() == numDefinitions + 2, "Number of form definition is not correct");
 
     }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20085

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

WIP 

* Tried fixing some of the failing tests after switching parent to `8.1.1.0` but there are still some failing tests
* I cannot explain exactly why it's failing after the switch but seems to be working ok previously (I'm having issues with my env debugging on `8.1.0.0` after switching to `8.1.1.0`)
* I also verified adding `jahia-depends` wasn't causing the issue (still failing even after removing)
* From what I can see in `8.1.1.0`, seems to be coming from the fact that we have two instances of the `nt-base.json` after [this change](https://github.com/Jahia/content-editor/commit/f80d948cf0152b33ba6a92a962ec533daf1fff98#diff-e41766942144368d21051091ef52cd23f5e12a5b20807b4008ca388489ff3c9aR2) cc @dgriffon and also maybe [this change](https://github.com/Jahia/content-editor/pull/1146) is also related
* This PR is still currently failing 2 assertions [here](https://github.com/Jahia/content-editor/compare/BACKLOG-20085-revert-fix-test?expand=1#diff-804bd151c59418f68c09d60b4b63b6c2c42e39e41ff784f65613a3b0519c867fR484) and [here](https://github.com/Jahia/content-editor/compare/BACKLOG-20085-revert-fix-test?expand=1#diff-804bd151c59418f68c09d60b4b63b6c2c42e39e41ff784f65613a3b0519c867fR356) that still needs to be resolved TBD. 