### PR TITLE
BACKLOG-20201: Update module dependencies; Fix CE tests

### DIFF
--- a/.github/maven.settings.xml
+++ b/.github/maven.settings.xml
@@ -41,6 +41,7 @@
 
     <activeProfiles>
         <activeProfile>jahia-internal-repository</activeProfile>
+        <activeProfile>unit-tests</activeProfile>
     </activeProfiles>
 
     <servers>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>content-editor</artifactId>
     <name>Jahia Content Editor</name>
-    <version>4.1.0</version>
+    <version>4.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Jahia Content Editor React extension.</description>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:git@github.com:Jahia/content-editor.git</connection>
         <developerConnection>scm:git:git@github.com:Jahia/content-editor.git</developerConnection>
         <url>https://github.com/Jahia/content-editor</url>
-        <tag>4_1_0</tag>
+        <tag>HEAD</tag>
     </scm>
     <properties>
         <jahia-module-type>system</jahia-module-type>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>content-editor</artifactId>
     <name>Jahia Content Editor</name>
-    <version>4.2.0-SNAPSHOT</version>
+    <version>4.1.0</version>
     <packaging>bundle</packaging>
     <description>Jahia Content Editor React extension.</description>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:git@github.com:Jahia/content-editor.git</connection>
         <developerConnection>scm:git:git@github.com:Jahia/content-editor.git</developerConnection>
         <url>https://github.com/Jahia/content-editor</url>
-        <tag>HEAD</tag>
+        <tag>4_1_0</tag>
     </scm>
     <properties>
         <jahia-module-type>system</jahia-module-type>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.1.0</version>
+        <version>8.1.0.0</version>
         <relativePath />
     </parent>
     <artifactId>content-editor</artifactId>
@@ -49,7 +49,7 @@
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-module-signature>MCwCFB5+Fa/WHCbtVxxuKu0Af4ZF0gUjAhR22ZoFtOrFzNhcvgVlpKZvAcS2Tw==</jahia-module-signature>
-        <jahia-depends>app-shell=2.7,graphql-dxm-provider=2.13,jcontent=2.8</jahia-depends>
+        <jahia-depends>app-shell=(2.6,3),graphql-dxm-provider=2.13,jcontent=(2.7,3)</jahia-depends>
         <import-package>
             com.fasterxml.jackson.annotation;version="[2.10,3)",
             com.fasterxml.jackson.databind;version="[2.10,3)",

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <dependency>
             <groupId>org.jahia.test</groupId>
             <artifactId>module-test-framework</artifactId>
-            <version>8.1.1.0</version>
+            <version>${parent.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-module-signature>MCwCFB5+Fa/WHCbtVxxuKu0Af4ZF0gUjAhR22ZoFtOrFzNhcvgVlpKZvAcS2Tw==</jahia-module-signature>
-        <jahia-depends>jcontent=[2.8,3)</jahia-depends>
+        <jahia-depends>app-shell=2.7,graphql-dxm-provider=2.13,jcontent=2.8</jahia-depends>
         <import-package>
             com.fasterxml.jackson.annotation;version="[2.10,3)",
             com.fasterxml.jackson.databind;version="[2.10,3)",

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.0.0</version>
+        <version>8.1.1.0</version>
         <relativePath />
     </parent>
     <artifactId>content-editor</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-        <jahia-module-signature>MCwCFGhPz7X+MNP7sw0OzaKrhYdyYC8rAhRBNrXwEWOy1RArpsP/IxuMhhF9Ig==</jahia-module-signature>
+        <jahia-module-signature>MCwCFB5+Fa/WHCbtVxxuKu0Af4ZF0gUjAhR22ZoFtOrFzNhcvgVlpKZvAcS2Tw==</jahia-module-signature>
         <jahia-depends>jcontent=[2.8,3)</jahia-depends>
         <import-package>
             com.fasterxml.jackson.annotation;version="[2.10,3)",

--- a/src/test/resources/META-INF/jahia-content-editor-forms/overrides/forms/nt_base.hidden-layout.json
+++ b/src/test/resources/META-INF/jahia-content-editor-forms/overrides/forms/nt_base.hidden-layout.json
@@ -5,7 +5,7 @@
   "sections": [
     {
       "name": "layout",
-      "hide:": "true"
+      "hide": "true"
     }
   ]
 }

--- a/tests/cypress/e2e/pickers/site.cy.ts
+++ b/tests/cypress/e2e/pickers/site.cy.ts
@@ -52,7 +52,10 @@ describe('Picker - Site', () => {
         const pickerField = contentEditor.getPickerField('qant:pickersMultiple_sitepicker', true);
         const picker = pickerField.open();
 
-        picker.getTable().selectItems(3);
+        let count = 3;
+        picker.getTable().selectItems(count);
+        cy.get('[data-cm-role="selection-table-collapse-button"] span')
+            .should('be.visible').and('contain', `${count} items selected`);
         picker.select();
 
         contentEditor.getPickerField('qant:pickersMultiple_sitepicker', true).get().scrollIntoView();

--- a/tests/cypress/page-object/pickerTable.ts
+++ b/tests/cypress/page-object/pickerTable.ts
@@ -29,7 +29,10 @@ export class PickerTable extends Table {
             .then(elems => {
                 expect(elems.length).gte(count);
                 const selectRow = elem =>
-                    cy.wrap(elem).find('[data-cm-role="table-content-list-cell-selection"] input').click();
+                    cy.wrap(elem)
+                      .find('[data-cm-role="table-content-list-cell-selection"] input')
+                      .click()
+                      .should('have.attr', 'aria-checked', "true");
                 for (let i = 0; i < count; i++) {
                     selectRow(elems.eq(i));
                 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20201

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

 * Revert the 4.1.0 release and update the module dependencies to make it clear we need:
   *  jahia-parent 8.1.1.0
   * app-shell=2.7+
   * graphql-dxm-provider=2.13+
   * jcontent=2.8+
   * Update module dependencies
 * Fix failing tests due to a change in definitions loaded https://github.com/Jahia/content-editor/blob/master/src/main/resources/META-INF/jahia-content-editor-forms/forms/nt_base.json#L2
   * This form definition was loaded during test init before ([here](https://github.com/Jahia/content-editor/blob/master/src/test/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImplTest.java#L103)) but is ignored due to missing nodeType attribute
   * Now that `nodeType` attribute has been added, it is now loaded during tests and affected validation of the number of sections
   * Because of this change, I also had to fix a bug (`mergeSections`) on how we do ordering of sections in form definitions based on priority which is needed to pass `testSectionPriorityOverride` test
 * Fix syntax issue with the `nt-base.hidden-layout.json` 