### PR TITLE
BACKLOG-16839: Display language switcher only for multi-language sites

### DIFF
--- a/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
+++ b/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
@@ -22,6 +22,11 @@ export const EditPanelLanguageSwitcher = ({siteInfo}) => {
 
     const switchLanguage = useSwitchLanguage();
 
+    // Do not display language switcher if site is not multi-language
+    if (!languages || languages.length <= 1) {
+        return null;
+    }
+
     return (
         <>
             <Dropdown

--- a/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.spec.jsx
+++ b/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {shallowWithTheme} from '@jahia/test-framework';
 import {dsGenericTheme} from '@jahia/design-system-kit';
 import {EditPanelLanguageSwitcher} from './index';
+import {useFormikContext} from 'formik';
 
 jest.mock('~/contexts/ContentEditor/ContentEditor.context', () => {
     return {
@@ -20,8 +21,11 @@ jest.mock('~/contexts/ContentEditorConfig/ContentEditorConfig.context', () => {
     };
 });
 
+jest.mock('formik');
+
 describe('EditPanelLanguageSwitcher', () => {
     let defaultProps;
+    let formik;
 
     beforeEach(() => {
         defaultProps = {
@@ -35,9 +39,27 @@ describe('EditPanelLanguageSwitcher', () => {
             },
             formik: {}
         };
+        formik = {
+            values: {}
+        };
+        useFormikContext.mockReturnValue(formik);
     });
 
-    it('should show language switcher', () => {
+    it('should NOT show language switcher with one language', () => {
+        const cmp = shallowWithTheme(
+            <EditPanelLanguageSwitcher {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+        expect(cmp.find('Dropdown').exists()).toBeFalsy();
+    });
+
+    it('should show language switcher with more than one language', () => {
+        defaultProps.siteInfo.languages.push({
+            language: 'fr',
+            displayName: 'French'
+        });
+
         const cmp = shallowWithTheme(
             <EditPanelLanguageSwitcher {...defaultProps}/>,
             {},


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16839

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->