### PR TITLE
SELENIUM-1560: Add scroll margin for fields

### DIFF
--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.scss
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Field/Field.scss
@@ -6,6 +6,8 @@
     padding: 8px 0 8px 8px;
 
     border-left: 4px solid transparent;
+
+    scroll-margin-top: var(--spacing-big);
 }
 
 .formControlError.formControlError {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/SELENIUM-1560

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix issue with selenium scrolling the fields but end up behind the sticky section title. 

Add scroll margin for fields to account for the sticky section title height.


