### PR TITLE
BACKLOG-16838: Separate non-filled languages in language switcher

### DIFF
--- a/src/javascript/ContentEditor/edit.gql-queries.js
+++ b/src/javascript/ContentEditor/edit.gql-queries.js
@@ -32,6 +32,7 @@ const NodeDataFragment = {
                     path
                     isFolder:isNodeType(type: {multi: ANY, types: ["jnt:contentFolder", "jnt:folder"]})
                 }
+                translationLanguages
                 name
                 displayName(language: $language)
                 mixinTypes {

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -173,10 +173,10 @@
       },
       "header":  {
         "languageSwitcher": {
-          "switchLanguage": "Switch language",
+          "switchLanguage": "Sprache wechseln",
           "addTranslation": {
-            "edit": "Add translation",
-            "create": "Create translation"
+            "edit": "Übersetzung hinzufügen",
+            "create": "Übersetzung erstellen"
           }
         },
         "chips": {

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -172,15 +172,17 @@
         }
       },
       "header":  {
+        "languageSwitcher": {
+          "switchLanguage": "Switch language",
+          "addTranslation": {
+            "edit": "Add translation",
+            "create": "Create translation"
+          }
+        },
         "chips": {
           "unsavedLabel": "Nicht gespeicherte Änderungen",
           "inCountLanguages": "in {{count}} Sprachen",
           "inAllLanguages": "in alle Sprachen"
-        }
-      },
-      "switchLanguage": {
-        "dialog": {
-          "title": "Wollen Sie die Änderungen speichern, bevor Sie die Sprache wechseln?"
         }
       },
       "error": {

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -176,6 +176,13 @@
         }
       },
       "header":  {
+        "languageSwitcher": {
+          "switchLanguage": "Switch language",
+          "addTranslation": {
+            "edit": "Add translation",
+            "create": "Create translation"
+          }
+        },
         "chips": {
           "unsavedLabel": "Unsaved changes",
           "inCountLanguages": "in {{count}} languages",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -173,10 +173,10 @@
       },
       "header":  {
         "languageSwitcher": {
-          "switchLanguage": "Switch language",
+          "switchLanguage": "Changer de langue",
           "addTranslation": {
-            "edit": "Add translation",
-            "create": "Create translation"
+            "edit": "Ajouter une traduction",
+            "create": "Créer une traduction"
           }
         },
         "chips": {

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -172,15 +172,17 @@
         }
       },
       "header":  {
+        "languageSwitcher": {
+          "switchLanguage": "Switch language",
+          "addTranslation": {
+            "edit": "Add translation",
+            "create": "Create translation"
+          }
+        },
         "chips": {
           "unsavedLabel": "Modifications non sauvegardées",
           "inCountLanguages": "dans {{count}} langues",
           "inAllLanguages": "dans toutes les langues"
-        }
-      },
-      "switchLanguage": {
-        "dialog": {
-          "title": "Enregistrer les modifications avant de changer de langue ?"
         }
       },
       "error": {

--- a/tests/cypress/e2e/languageSwitcher.cy.ts
+++ b/tests/cypress/e2e/languageSwitcher.cy.ts
@@ -1,0 +1,110 @@
+import {JContent} from '../page-object/jcontent';
+import gql from 'graphql-tag';
+
+describe('Language switcher tests', () => {
+    const siteKey = 'digitall';
+    let jcontent: JContent;
+    const createText = gql`
+        mutation createText {
+            jcr {
+                mutateNode(pathOrId: "/sites/digitall/contents") {
+                    addChild(name: "lang-switcher-test", primaryNodeType: "jnt:contentFolder") {
+                        addChild(
+                            name: "lang-switcher-text", 
+                            primaryNodeType: "jnt:text", 
+                            properties: [{ name: "text", language: "fr", value: "bonjour" }]
+                        ) {
+                            uuid
+                        }
+                    }
+                }
+            }
+        }
+    `;
+
+    beforeEach(() => {
+        // I have issues adding these to before()/after() so have to add to beforeEach()/afterEach()
+        cy.login(); // Edit in chief
+
+        // BeforeEach()
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+    });
+
+    afterEach(() => {
+        cy.logout();
+    });
+
+    function langInGroup(elems, lang, dropdownGroup) {
+        const groupText = elems.find(`:contains("${lang}")`)
+            .parents('[data-option-type="group"]')
+            .find('.moonstone-title')
+            .text();
+        expect(groupText).to.equals(dropdownGroup);
+    }
+
+    it('Create content - should have all language options in "Create translation" group', () => {
+        const ce = jcontent.createContent('Simple text');
+        cy.get('#contenteditor-dialog-title')
+            .should('be.visible')
+            .and('contain', 'Create Simple text');
+
+        ce.getLanguageSwitcher().get().click()
+            .get('li.moonstone-menuItem[role="option"]')
+            .should(elems => {
+                expect(elems).to.have.length(3);
+                langInGroup(elems, 'English', 'Create translation');
+                langInGroup(elems, 'Deutsch', 'Create translation');
+                langInGroup(elems, 'Français', 'Create translation');
+            });
+    });
+
+    it('Create content - should have edited language in "View language" group after edit', () => {
+        const ce = jcontent.createContent('Simple text');
+        cy.get('#contenteditor-dialog-title')
+            .should('be.visible')
+            .and('contain', 'Create Simple text');
+
+        // Verify English is selected by default
+        ce.getLanguageSwitcher().get().find('span[title="English"]').should('be.visible');
+
+        // Type text
+        ce.openSection('Content').get().find('input[type="text"]').clear().type('cypress-test');
+
+        // Switch language
+        ce.getLanguageSwitcher().select('Deutsch');
+
+        // Verify language switcher
+        const langSwitcher = ce.getLanguageSwitcher();
+        langSwitcher.get().click()
+            .get('li.moonstone-menuItem[role="option"]')
+            .should(elems => {
+                expect(elems).to.have.length(3);
+                langInGroup(elems, 'English', 'Switch language');
+                langInGroup(elems, 'Deutsch', 'Create translation');
+                langInGroup(elems, 'Français', 'Create translation');
+            });
+    });
+
+    it('Edit content - Should have edited language in "View language" group', () => {
+        cy.apollo({mutation: createText});
+        const ce = JContent.visit(siteKey, 'en', 'content-folders/contents/lang-switcher-test')
+            .editComponentByText('lang-switcher-text');
+
+        // Verify language switcher
+        const langSwitcher = ce.getLanguageSwitcher();
+        langSwitcher.get().click()
+            .get('li.moonstone-menuItem[role="option"]')
+            .should(elems => {
+                expect(elems).to.have.length(3);
+                langInGroup(elems, 'English', 'Add translation');
+                langInGroup(elems, 'Deutsch', 'Add translation');
+                langInGroup(elems, 'Français', 'Switch language');
+            });
+
+        cy.apollo({mutation: gql`
+                mutation deleteContent {
+                    jcr { deleteNode(pathOrId: "/sites/digitall/contents/lang-switcher-test") }
+                }
+            `});
+    });
+});

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -81,7 +81,7 @@ export class ContentEditor extends BasePage {
 
     getLanguageSwitcher(): Dropdown {
         if (!this.languageSwitcher) {
-            this.languageSwitcher = getComponentByAttr(Dropdown, 'data-cm-role', 'language-switcher');
+            this.languageSwitcher = getComponentBySelector(Dropdown, '#contenteditor-dialog-title [data-cm-role="language-switcher"]');
         }
 
         return this.languageSwitcher;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16838

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Depends on this PR: https://github.com/Jahia/graphql-core/pull/277

Refactor language dropdown to split into option groups depending on whether language already has been translated or currently filled in edit mode.

Added cypress tests for language switcher as well.