### PR TITLE
BACKLOG-16838: Fix language dropdown grouping for empty values

### DIFF
--- a/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
+++ b/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
@@ -26,7 +26,9 @@ export const EditPanelLanguageSwitcher = ({siteInfo}) => {
             }
 
             // Group language options depending on whether node has been translated to this language already or not
-            const isTranslated = translatedLangs.includes(item.language) || i18nContext[item.language];
+            const isTranslated = translatedLangs.includes(item.language) ||
+                // Check if a translation during create is empty or not
+                (i18nContext[item.language]?.values && Object.values(i18nContext[item.language]?.values).some(Boolean));
             const group = isTranslated ? translatedOption : notTranslatedOption;
             group.options.push({
                 label,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16838

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add additional check to see if edited i18n value is empty or not. Empty values are considered not translated.