### PR TITLE
BACKLOG-20448: Uncontextualize content picker and allow usage in API

### DIFF
--- a/src/javascript/ContentEditorApi/ContentPickerApi.jsx
+++ b/src/javascript/ContentEditorApi/ContentPickerApi.jsx
@@ -1,0 +1,40 @@
+import React, {useState} from 'react';
+import {PickerDialog} from '~/SelectorTypes/Picker';
+import {useContentEditorApiContext} from '~/contexts/ContentEditorApi/ContentEditorApi.context';
+import {mergeDeep} from '~/SelectorTypes/Picker/Picker.utils';
+import {DefaultPickerConfig} from '~/SelectorTypes/Picker/configs/DefaultPickerConfig';
+import {registry} from '@jahia/ui-extender';
+
+export const ContentPickerApi = () => {
+    const [picker, setPicker] = useState(false);
+
+    const context = useContentEditorApiContext();
+
+    context.openPicker = options => {
+        setPicker(options);
+    };
+
+    window.CE_API = window.CE_API || {};
+    window.CE_API.openPicker = context.openPicker;
+
+    const pickerConfig = picker && mergeDeep({}, DefaultPickerConfig, registry.get('pickerConfiguration', picker.type) || registry.get('pickerConfiguration', 'editorial'));
+
+    const handleItemSelection = pickerResult => {
+        setPicker(false);
+        picker.setValue(pickerResult);
+    };
+
+    return picker && (
+        <PickerDialog
+            isOpen={Boolean(picker)}
+            initialSelectedItem={picker?.value}
+            site={picker?.site}
+            pickerConfig={pickerConfig}
+            lang={picker?.lang}
+            uilang={picker?.uilang}
+            isMultiple={picker?.isMultiple}
+            onItemSelection={handleItemSelection}
+            onClose={() => setPicker(false)}
+        />
+    );
+};

--- a/src/javascript/ContentEditorApi/index.js
+++ b/src/javascript/ContentEditorApi/index.js
@@ -1,1 +1,2 @@
 export * from './ContentEditorApi';
+export * from './ContentPickerApi';

--- a/src/javascript/SelectorTypes/Picker/Picker.jsx
+++ b/src/javascript/SelectorTypes/Picker/Picker.jsx
@@ -10,15 +10,17 @@ import {getButtonRenderer} from '~/utils';
 import {LoaderOverlay} from '~/DesignSystem/LoaderOverlay';
 import styles from './Picker.scss';
 import {Button} from '@jahia/moonstone';
-import {FieldContextProvider} from '~/contexts/FieldContext';
 import {DefaultPickerConfig} from '~/SelectorTypes/Picker/configs/DefaultPickerConfig';
 import {useFormikContext} from 'formik';
 import {OrderableValue} from '~/DesignSystem/OrderableValue/OrderableValue';
+import {useContentEditorConfigContext} from '~/contexts';
 
 const ButtonRenderer = getButtonRenderer({labelStyle: 'none', defaultButtonProps: {variant: 'ghost'}});
 
 export const Picker = ({field, value, editorContext, inputContext, onChange, onBlur}) => {
     const {t} = useTranslation('content-editor');
+    const {lang, uilang} = useContentEditorConfigContext();
+
     const parsedOptions = {};
     field.selectorOptions.forEach(option => {
         set(parsedOptions, option.name, option.value || option.values);
@@ -151,18 +153,18 @@ export const Picker = ({field, value, editorContext, inputContext, onChange, onB
                     )}
                 </>}
 
-            <FieldContextProvider field={field}>
-                <PickerDialog
-                    isOpen={isDialogOpen}
-                    editorContext={editorContext}
-                    pickerConfig={pickerConfig}
-                    initialSelectedItem={fieldData && fieldData.map(f => f.path)}
-                    accordionItemProps={mergeDeep({}, pickerConfig.accordionItem, parsedOptions.accordionItem)}
-                    onClose={() => setDialogOpen(false)}
-                    onItemSelection={onItemSelection}
-                />
-            </FieldContextProvider>
-
+            <PickerDialog
+                isOpen={isDialogOpen}
+                site={editorContext.site}
+                pickerConfig={pickerConfig}
+                initialSelectedItem={fieldData && fieldData.map(f => f.path)}
+                accordionItemProps={mergeDeep({}, pickerConfig.accordionItem, parsedOptions.accordionItem)}
+                lang={lang}
+                uilang={uilang}
+                isMultiple={field.multiple}
+                onClose={() => setDialogOpen(false)}
+                onItemSelection={onItemSelection}
+            />
         </div>
     );
 };

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/PickerDialog.jsx
@@ -5,7 +5,8 @@ import styles from './PickerDialog.scss';
 import {
     cePickerClearSelection,
     cePickerMode,
-    cePickerPath, cePickerSetMultiple,
+    cePickerPath,
+    cePickerSetMultiple,
     cePickerSetPage,
     cePickerSetSearchTerm
 } from '~/SelectorTypes/Picker/Picker.redux';
@@ -17,7 +18,6 @@ import RightPanel from './RightPanel';
 import {ContentNavigation} from '@jahia/jcontent';
 import {SelectionHandler} from '~/SelectorTypes/Picker/PickerDialog/SelectionHandler';
 import {PickerSiteSwitcher} from '~/SelectorTypes/Picker/PickerDialog/PickerSiteSwitcher';
-import {useFieldContext} from '~/contexts/FieldContext';
 
 const Transition = props => (
     <Slide direction="up"
@@ -39,20 +39,22 @@ export const PickerDialog = ({
     isOpen,
     onClose,
     initialSelectedItem,
-    editorContext,
+    site,
     pickerConfig,
+    lang,
+    uilang,
+    isMultiple,
     accordionItemProps,
     onItemSelection
 }) => {
     const dispatch = useDispatch();
-    const {multiple} = useFieldContext();
 
     useEffect(() => {
         if (isOpen) {
             dispatch(batchActions([
                 cePickerSetSearchTerm(''),
                 cePickerSetPage(0),
-                cePickerSetMultiple(multiple)
+                cePickerSetMultiple(isMultiple)
             ]));
         }
 
@@ -61,7 +63,7 @@ export const PickerDialog = ({
                 dispatch(cePickerClearSelection());
             }
         };
-    }, [dispatch, pickerConfig.key, isOpen, multiple]);
+    }, [dispatch, pickerConfig.key, isOpen, isMultiple]);
 
     return (
         <Dialog
@@ -75,7 +77,7 @@ export const PickerDialog = ({
             onClose={onClose}
         >
             <div className="flexFluid flexRow_nowrap">
-                <SelectionHandler editorContext={editorContext} pickerConfig={pickerConfig} accordionItemProps={accordionItemProps} initialSelectedItem={initialSelectedItem}>
+                <SelectionHandler site={site} pickerConfig={pickerConfig} accordionItemProps={accordionItemProps} initialSelectedItem={initialSelectedItem} lang={lang} uilang={uilang}>
                     {booleanValue(pickerConfig.pickerDialog.displayTree) && (
                         <aside>
                             <ContentNavigation
@@ -92,7 +94,7 @@ export const PickerDialog = ({
                             />
                         </aside>
                     )}
-                    <RightPanel pickerConfig={pickerConfig} accordionItemProps={accordionItemProps} onClose={onClose} onItemSelection={onItemSelection}/>
+                    <RightPanel pickerConfig={pickerConfig} accordionItemProps={accordionItemProps} isMultiple={isMultiple} lang={lang} uilang={uilang} onClose={onClose} onItemSelection={onItemSelection}/>
                 </SelectionHandler>
             </div>
         </Dialog>
@@ -102,10 +104,13 @@ export const PickerDialog = ({
 PickerDialog.propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    editorContext: PropTypes.object.isRequired,
+    site: PropTypes.string.isRequired,
     pickerConfig: configPropType.isRequired,
     initialSelectedItem: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
     accordionItemProps: PropTypes.object,
+    lang: PropTypes.string,
+    uilang: PropTypes.string,
+    isMultiple: PropTypes.bool,
     onItemSelection: PropTypes.func.isRequired
 };
 

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentLayout.container.jsx
@@ -33,7 +33,7 @@ function expand(r, level) {
     return (r && level) ? r.filter(c => c.hasSubRows).flatMap(c => [c.path, ...expand(c.subRows, level - 1)]) : [];
 }
 
-export const ContentLayoutContainer = ({pickerConfig, accordionItemProps}) => {
+export const ContentLayoutContainer = ({pickerConfig, isMultiple, accordionItemProps}) => {
     const {t} = useTranslation();
     const currentResult = useRef();
     const {mode, path, filesMode, preSearchModeMemo, viewType} = useSelector(state => ({
@@ -117,6 +117,7 @@ export const ContentLayoutContainer = ({pickerConfig, accordionItemProps}) => {
 
         return (
             <ContentTable isContentNotFound
+                          isMultiple={isMultiple}
                           path={path}
                           filesMode={filesMode}
                           rows={[]}
@@ -150,6 +151,7 @@ export const ContentLayoutContainer = ({pickerConfig, accordionItemProps}) => {
             )}
             {(mode === Constants.mode.MEDIA || preSearchModeMemo === Constants.mode.MEDIA) && filesMode === Constants.fileView.mode.THUMBNAILS ? (
                 <FilesGrid rows={rows}
+                           isMultiple={isMultiple}
                            totalCount={totalCount}
                            isLoading={loading}
                            pickerConfig={pickerConfig}
@@ -157,6 +159,7 @@ export const ContentLayoutContainer = ({pickerConfig, accordionItemProps}) => {
                 />
             ) : (
                 <ContentTable path={path}
+                              isMultiple={isMultiple}
                               rows={rows}
                               isStructured={isStructured}
                               isLoading={loading}
@@ -171,6 +174,7 @@ export const ContentLayoutContainer = ({pickerConfig, accordionItemProps}) => {
 
 ContentLayoutContainer.propTypes = {
     pickerConfig: configPropType.isRequired,
+    isMultiple: PropTypes.bool,
     accordionItemProps: PropTypes.object
 };
 

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/ContentTable.jsx
@@ -29,7 +29,6 @@ import {
     useFileDrop
 } from '@jahia/jcontent';
 import {registry} from '@jahia/ui-extender';
-import {useFieldContext} from '~/contexts/FieldContext';
 import {configPropType} from '~/SelectorTypes/Picker/configs/configPropType';
 import {Row} from '~/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/Row';
 import clsx from 'clsx';
@@ -63,9 +62,8 @@ const SELECTION_COLUMN_ID = 'selection';
 
 const defaultCols = ['publicationStatus', 'name', 'type', 'lastModified'];
 
-export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, isStructured, pickerConfig, accordionItemProps}) => {
+export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, isStructured, pickerConfig, isMultiple, accordionItemProps}) => {
     const {t} = useTranslation();
-    const field = useFieldContext();
     const dispatch = useDispatch();
 
     const {mode, preSearchModeMemo, path, pagination, searchTerm, openPaths, sort} = useSelector(state => ({
@@ -101,14 +99,14 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
                 Header: reactTable.Header,
                 ...c
             }));
-        const multiple = field.multiple && flattenRows.some(r => r.isSelectable);
+        const multiple = isMultiple && flattenRows.some(r => r.isSelectable);
         columns.splice((columns[0].id === 'publicationStatus') ? 1 : 0, 0, allColumnData.find(col => col.id === 'selection'));
         columns.push(allColumnData.find(col => col.id === 'visibleActions'));
 
         return columns
             .filter(c => multiple || c.id !== SELECTION_COLUMN_ID)
             .filter(c => previousModeTableConfig?.contextualMenu || c.id !== 'visibleActions');
-    }, [field.multiple, previousModeTableConfig, rows, isStructured]);
+    }, [isMultiple, previousModeTableConfig, rows, isStructured]);
     const {
         getTableProps,
         getTableBodyProps,
@@ -133,7 +131,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
                 dispatch(cePickerSetSort({order, orderBy: column.property}));
             }
         },
-        field.multiple ? useRowMultipleSelection : useRowSelection,
+        isMultiple ? useRowMultipleSelection : useRowSelection,
         reactTable.useSort,
         reactTable.useExpandedControlled
     );
@@ -180,7 +178,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
     }
 
     const handleOnClick = (e, row) => {
-        if (field.multiple) {
+        if (isMultiple) {
             return; // Use selection column instead of row click for multiple selection
         }
 
@@ -218,7 +216,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
                                 <Row key={'row' + row.id}
                                      isStructured={isStructured}
                                      row={row}
-                                     field={field}
+                                     isMultiple={isMultiple}
                                      tableConfig={tableConfig}
                                      handleOnClick={handleOnClick}
                                      handleOnDoubleClick={handleOnDoubleClick}
@@ -253,6 +251,7 @@ ContentTable.propTypes = {
     rows: PropTypes.array.isRequired,
     totalCount: PropTypes.number.isRequired,
     pickerConfig: configPropType.isRequired,
+    isMultiple: PropTypes.bool,
     accordionItemProps: PropTypes.object
 };
 

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/Row.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/ContentTable/Row.jsx
@@ -11,7 +11,7 @@ export const Row = ({
     isStructured,
     row,
     tableConfig,
-    field,
+    isMultiple,
     previousModeTableConfig,
     handleOnDoubleClick,
     handleOnClick
@@ -50,7 +50,7 @@ export const Row = ({
                       'moonstone-drop_row': (isCanDrop || isCanDropFile),
                       [styles.disabled]: isStructured && !node.isSelectable
                   })}
-                  isHighlighted={selectionProps.checked && !field.multiple}
+                  isHighlighted={selectionProps.checked && !isMultiple}
                   onClick={e => handleOnClick(e, row)}
                   onContextMenu={event => {
                       if (tableConfig.contextualMenu) {
@@ -74,7 +74,7 @@ Row.propTypes = {
     isStructured: PropTypes.bool,
     row: PropTypes.object.isRequired,
     previousModeTableConfig: PropTypes.object,
-    field: PropTypes.object,
+    isMultiple: PropTypes.bool,
     tableConfig: PropTypes.object,
     doubleClickNavigation: PropTypes.func,
     handleOnClick: PropTypes.func,

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/FilesGrid/FilesGrid.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/ContentLayout/FilesGrid/FilesGrid.jsx
@@ -5,6 +5,7 @@ import {FileCard, FilesGridEmptyDropZone, jcontentUtils, useFileDrop} from '@jah
 import {TablePagination} from '@jahia/moonstone';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import classNames from 'clsx';
+import clsx from 'clsx';
 import styles from './FilesGrid.scss';
 import {
     cePickerAddSelection,
@@ -18,10 +19,8 @@ import {
 } from '~/SelectorTypes/Picker/Picker.redux';
 import {getDetailedPathArray} from '~/SelectorTypes/Picker/Picker.utils';
 import {batchActions} from 'redux-batched-actions';
-import {useFieldContext} from '~/contexts/FieldContext';
 import {registry} from '@jahia/ui-extender';
 import {configPropType} from '~/SelectorTypes/Picker/configs/configPropType';
-import clsx from 'clsx';
 
 const reduxActions = {
     setOpenPathAction: path => cePickerOpenPaths(getDetailedPathArray(path)),
@@ -44,7 +43,7 @@ Grid.propTypes = {
     children: PropTypes.node
 };
 
-export const FilesGrid = ({totalCount, rows, isLoading, pickerConfig, accordionItemProps}) => {
+export const FilesGrid = ({totalCount, rows, isLoading, pickerConfig, isMultiple, accordionItemProps}) => {
     const {t} = useTranslation('jcontent');
     const {mode, path, pagination, siteKey, uilang, lang, selection} = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
@@ -56,13 +55,12 @@ export const FilesGrid = ({totalCount, rows, isLoading, pickerConfig, accordionI
         selection: state.contenteditor.picker.selection
     }), shallowEqual);
     const dispatch = useDispatch();
-    const field = useFieldContext();
     const tableConfig = useMemo(() => {
         return jcontentUtils.getAccordionItem(registry.get('accordionItem', mode), accordionItemProps)?.tableConfig;
     }, [mode, accordionItemProps]);
     const onPreviewSelect = previewSelection => {
         const actions = [];
-        if (!field.multiple) {
+        if (!isMultiple) {
             actions.push(reduxActions.clearSelection());
         }
 
@@ -150,6 +148,7 @@ FilesGrid.propTypes = {
     rows: PropTypes.array.isRequired,
     totalCount: PropTypes.number.isRequired,
     pickerConfig: configPropType.isRequired,
+    isMultiple: PropTypes.bool,
     accordionItemProps: PropTypes.object
 };
 

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/PickerSelection/SelectionCaption.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/PickerSelection/SelectionCaption.jsx
@@ -5,7 +5,6 @@ import {Typography} from '@jahia/moonstone';
 import {useTranslation} from 'react-i18next';
 import styles from './Selection.scss';
 import {SelectionButton} from '~/SelectorTypes/Picker/PickerDialog/RightPanel/PickerSelection/SelectionButton';
-import {useFieldContext} from '~/contexts/FieldContext';
 import {NodeIcon} from '@jahia/jcontent';
 import {configPropType} from '~/SelectorTypes/Picker/configs/configPropType';
 
@@ -23,9 +22,8 @@ DefaultCaptionComponent.propTypes = {
     selection: PropTypes.object.isRequired
 };
 
-const SelectionCaption = ({selection, expanded, pickerConfig}) => {
+const SelectionCaption = ({selection, expanded, pickerConfig, isMultiple}) => {
     const {t} = useTranslation('content-editor');
-    const field = useFieldContext();
     const isExpanded = expanded[0];
     const CaptionComponent = pickerConfig.pickerCaptionComponent || DefaultCaptionComponent;
     return (
@@ -36,11 +34,11 @@ const SelectionCaption = ({selection, expanded, pickerConfig}) => {
                 </Typography>)}
 
             {/* Single selection caption */}
-            {selection.length > 0 && !field.multiple && (
+            {selection.length > 0 && !isMultiple && (
                 <CaptionComponent selection={selection[0]}/>
             )}
             {/* Multiple selection caption */}
-            {selection.length > 0 && field.multiple && (
+            {selection.length > 0 && isMultiple && (
                 <SelectionButton
                     data-sel-role={`${selection.length}-item-selected`}
                     className={clsx({[styles.hidden]: isExpanded})}
@@ -54,7 +52,8 @@ const SelectionCaption = ({selection, expanded, pickerConfig}) => {
 SelectionCaption.propTypes = {
     selection: PropTypes.array.isRequired,
     pickerConfig: configPropType.isRequired,
-    expanded: PropTypes.array.isRequired
+    expanded: PropTypes.array.isRequired,
+    isMultiple: PropTypes.bool
 };
 
 export default SelectionCaption;

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/RightPanel/RightPanel.jsx
@@ -13,14 +13,13 @@ import {SelectionCaption, SelectionTable} from './PickerSelection';
 import {Search} from './Search';
 import {PickerSiteSwitcher} from '~/SelectorTypes/Picker';
 import {jcontentUtils} from '@jahia/jcontent';
-import {useContentEditorConfigContext} from '~/contexts';
 import {replaceFragmentsInDocument} from '@jahia/data-helper';
 import {GET_PICKER_NODE_UUID} from '~/SelectorTypes/Picker/PickerDialog/PickerDialog.gql-queries';
 import {useQuery} from '@apollo/react-hooks';
 
 const ButtonRenderer = getButtonRenderer({defaultButtonProps: {variant: 'ghost'}});
 
-const RightPanel = ({pickerConfig, accordionItemProps, onClose, onItemSelection}) => {
+const RightPanel = ({pickerConfig, isMultiple, accordionItemProps, lang, uilang, onClose, onItemSelection}) => {
     const {selection, mode, path} = useSelector(state => ({
         path: state.contenteditor.picker.path,
         selection: state.contenteditor.picker.selection,
@@ -28,7 +27,6 @@ const RightPanel = ({pickerConfig, accordionItemProps, onClose, onItemSelection}
     }), shallowEqual);
     const selectionExpanded = useState(false);
     const {t} = useTranslation('content-editor');
-    const {lang, uilang} = useContentEditorConfigContext();
 
     const fragments = (pickerConfig?.selectionTable?.getFragments?.() || []);
     const selectionQuery = replaceFragmentsInDocument(GET_PICKER_NODE_UUID, fragments);
@@ -73,12 +71,12 @@ const RightPanel = ({pickerConfig, accordionItemProps, onClose, onItemSelection}
                 </div>
             </header>
             <div className={clsx('flexFluid', 'flexCol_nowrap', css.body)}>
-                {mode !== '' && <ContentLayout pickerConfig={pickerConfig} accordionItemProps={accordionItemProps}/>}
+                {mode !== '' && <ContentLayout pickerConfig={pickerConfig} isMultiple={isMultiple} accordionItemProps={accordionItemProps}/>}
             </div>
 
             <SelectionTable selection={nodes} expanded={selectionExpanded} pickerConfig={pickerConfig}/>
             <footer className={clsx('flexRow', 'alignCenter', css.footer)}>
-                <SelectionCaption selection={nodes} pickerConfig={pickerConfig} expanded={selectionExpanded}/>
+                <SelectionCaption selection={nodes} pickerConfig={pickerConfig} expanded={selectionExpanded} isMultiple={isMultiple}/>
                 <div className={clsx('flexRow', css.actions)}>
                     <Button
                         data-sel-picker-dialog-action="cancel"
@@ -102,7 +100,10 @@ const RightPanel = ({pickerConfig, accordionItemProps, onClose, onItemSelection}
 
 RightPanel.propTypes = {
     pickerConfig: configPropType.isRequired,
+    isMultiple: PropTypes.bool,
     accordionItemProps: PropTypes.object,
+    lang: PropTypes.string,
+    uilang: PropTypes.string,
     onItemSelection: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired
 };

--- a/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/PickerDialog/SelectionHandler.jsx
@@ -1,7 +1,6 @@
 import React, {useEffect, useRef} from 'react';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import {replaceFragmentsInDocument, useNodeInfo} from '@jahia/data-helper';
-import {useContentEditorConfigContext} from '~/contexts';
 import {useQuery} from '@apollo/react-hooks';
 import {GET_PICKER_NODE} from '~/SelectorTypes/Picker';
 import {
@@ -28,7 +27,7 @@ function getSite(selectedItem) {
     return (pathElements[1] === 'sites') ? pathElements[2] : undefined;
 }
 
-export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConfig, accordionItemProps, children}) => {
+export const SelectionHandler = ({initialSelectedItem, site, pickerConfig, accordionItemProps, lang, uilang, children}) => {
     const state = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
         modes: state.contenteditor.picker.modes,
@@ -42,7 +41,6 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
     const dispatch = useDispatch();
 
     const currentFolderInfo = useNodeInfo({path: state.path}, {skip: !state.path});
-    const {lang, uilang} = useContentEditorConfigContext();
 
     const paths = (Array.isArray(initialSelectedItem) ? initialSelectedItem : [initialSelectedItem]).filter(f => f);
     let accordion;
@@ -94,7 +92,7 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
             allAccordionItems[0];
 
         if (!previousState.current.isOpen) {
-            newState.site = editorContext.site;
+            newState.site = site;
         }
 
         // If selection exists we don't care about previous state, need to update state in accordance with selection
@@ -159,7 +157,7 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
         }
 
         previousState.current = newState;
-    }, [dispatch, editorContext, pickerConfig, state, nodesInfo, currentFolderInfo, accordion.key, accordionItemProps]);
+    }, [dispatch, site, pickerConfig, state, nodesInfo, currentFolderInfo, accordion.key, accordionItemProps]);
 
     if (currentFolderInfo.loading || nodesInfo.loading) {
         return <LoaderOverlay/>;
@@ -170,8 +168,10 @@ export const SelectionHandler = ({initialSelectedItem, editorContext, pickerConf
 
 SelectionHandler.propTypes = {
     initialSelectedItem: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-    editorContext: PropTypes.object.isRequired,
+    site: PropTypes.string.isRequired,
     pickerConfig: configPropType.isRequired,
     accordionItemProps: PropTypes.object,
+    lang: PropTypes.string,
+    uilang: PropTypes.string,
     children: PropTypes.node
 };

--- a/src/javascript/SelectorTypes/RichText/RichText.jsx
+++ b/src/javascript/SelectorTypes/RichText/RichText.jsx
@@ -77,7 +77,7 @@ export const RichText = ({field, id, value, onChange, onBlur}) => {
     }
 
     const handlePickerDialog = (setUrl, type, params, dialog) => {
-        const value = getPickerValue(type, dialog);
+        const value = getPickerValue(dialog);
 
         api.openPicker({
             type,

--- a/src/javascript/SelectorTypes/RichText/RichText.utils.js
+++ b/src/javascript/SelectorTypes/RichText/RichText.utils.js
@@ -1,44 +1,34 @@
-import {registry} from '@jahia/ui-extender';
-import {mergeDeep} from '~/SelectorTypes/Picker/Picker.utils';
-import {DefaultPickerConfig} from '~/SelectorTypes/Picker/configs/DefaultPickerConfig';
-
 const contextPath = (window.contextJsParameters && window.contextJsParameters.contextPath) || '';
 
 const contentPrefix = `${contextPath}/cms/{mode}/{lang}`;
 const filePrefix = `${contextPath}/files/{workspace}`;
 
 // Find "URL" input in CKEditor dialog.
-function getCKEditorUrlInputId(picker) {
-    if (!picker.dialog) {
+function getCKEditorUrlInputId(dialog) {
+    if (!dialog) {
         return;
     }
 
-    const hasUrl = picker.dialog.getContentElement('info', 'url');
-    const eltId = hasUrl ? 'url' : 'txtUrl';
-
-    return eltId;
+    const hasUrl = dialog.getContentElement('info', 'url');
+    return hasUrl ? 'url' : 'txtUrl';
 }
 
-export function fillCKEditorPicker(picker, pickerResult) {
+export function fillCKEditorPicker(setUrl, dialog, contentPicker, pickerResult) {
     // Fill Dialog alt title
-    const eltId = getCKEditorUrlInputId(picker);
+    const eltId = getCKEditorUrlInputId(dialog);
 
-    picker.dialog
+    dialog
         .getContentElement('info', eltId === 'url' ? 'advTitle' : 'txtAlt')
         .setValue(pickerResult.name);
 
     // Wrap path to build Jahia url.
-    picker.setUrl(`${picker.contentPicker ? contentPrefix : filePrefix}${pickerResult.path}${picker.contentPicker ? '.html' : ''}`, {});
+    setUrl(`${contentPicker ? contentPrefix : filePrefix}${pickerResult.path}${contentPicker ? '.html' : ''}`, {});
 }
 
-export function buildPickerContext(picker) {
-    const pickerConfig = mergeDeep({}, DefaultPickerConfig, registry.get('pickerConfiguration', picker.type) || registry.get('pickerConfiguration', 'editorial'));
-
-    const urlInput = picker.dialog.getContentElement('info', getCKEditorUrlInputId(picker));
+export function getPickerValue(type, dialog) {
+    const urlInput = dialog.getContentElement('info', getCKEditorUrlInputId(dialog));
     const valueInInput = urlInput ? urlInput.getValue() : '';
-    const currentValue = valueInInput.startsWith(contentPrefix) ?
+    return valueInInput.startsWith(contentPrefix) ?
         valueInInput.substr(contentPrefix.length).slice(0, -('.html').length) :
         valueInInput.substr(filePrefix.length);
-
-    return {pickerConfig, currentValue};
 }

--- a/src/javascript/SelectorTypes/RichText/RichText.utils.js
+++ b/src/javascript/SelectorTypes/RichText/RichText.utils.js
@@ -25,7 +25,7 @@ export function fillCKEditorPicker(setUrl, dialog, contentPicker, pickerResult) 
     setUrl(`${contentPicker ? contentPrefix : filePrefix}${pickerResult.path}${contentPicker ? '.html' : ''}`, {});
 }
 
-export function getPickerValue(type, dialog) {
+export function getPickerValue(dialog) {
     const urlInput = dialog.getContentElement('info', getCKEditorUrlInputId(dialog));
     const valueInInput = urlInput ? urlInput.getValue() : '';
     return valueInInput.startsWith(contentPrefix) ?

--- a/src/javascript/SelectorTypes/RichText/RichText.utils.spec.js
+++ b/src/javascript/SelectorTypes/RichText/RichText.utils.spec.js
@@ -1,4 +1,4 @@
-import {getPickerValue, fillCKEditorPicker} from './RichText.utils';
+import {fillCKEditorPicker, getPickerValue} from './RichText.utils';
 
 jest.mock('@jahia/ui-extender', () => {
     return {
@@ -16,49 +16,42 @@ jest.mock('@jahia/ui-extender', () => {
 });
 
 describe('RichText utils', () => {
-    describe('buildPickerContext', () => {
-        let picker;
+    describe('getPickerValue', () => {
+        let dialog;
 
         beforeEach(() => {
-            picker = {
-                dialog: {
-                    getContentElement: jest.fn()
-                }
+            dialog = {
+                getContentElement: jest.fn()
             };
         });
 
-        it('should always displayTree', () => {
-            const {pickerConfig} = getPickerValue(picker);
-            expect(pickerConfig.displayTree).toBe(true);
-        });
-
         it('should an empty currentValue when input is empty', () => {
-            const {currentValue} = getPickerValue(picker);
+            const currentValue = getPickerValue(dialog);
             expect(currentValue).toBe('');
         });
 
         it('should remove the content prefix form the url', () => {
-            picker.dialog.getContentElement.mockImplementation(() => {
+            dialog.getContentElement.mockImplementation(() => {
                 return {
                     getValue: () => '/cms/{mode}/{lang}/richTextEdition/toot/al/regal.html'
                 };
             });
-            const {currentValue} = getPickerValue(picker);
+            const currentValue = getPickerValue(dialog);
             expect(currentValue).toBe('/richTextEdition/toot/al/regal');
         });
 
         it('should remove the file prefix form the url', () => {
-            picker.dialog.getContentElement.mockImplementation(() => {
+            dialog.getContentElement.mockImplementation(() => {
                 return {
                     getValue: () => '/files/{workspace}/richTextEdition/toot/al/regal.html'
                 };
             });
-            const {currentValue} = getPickerValue(picker);
+            const currentValue = getPickerValue(dialog);
             expect(currentValue).toBe('/richTextEdition/toot/al/regal.html');
         });
 
         it('should take urlTxt when url is null', () => {
-            picker.dialog.getContentElement.mockImplementation((_, id) => {
+            dialog.getContentElement.mockImplementation((_, id) => {
                 if (id !== 'txtUrl') {
                     return;
                 }
@@ -67,41 +60,41 @@ describe('RichText utils', () => {
                     getValue: () => '/files/{workspace}/richTextEdition/toot/al/regal.html'
                 };
             });
-            const {currentValue} = getPickerValue(picker);
+            const currentValue = getPickerValue(dialog);
             expect(currentValue).toBe('/richTextEdition/toot/al/regal.html');
         });
     });
 
     describe('fillCKEditorPicker', () => {
-        let picker;
+        let dialog;
+        let contentPicker;
+        let setUrl;
 
         beforeEach(() => {
-            picker = {
-                dialog: {
-                    getContentElement: jest.fn(() => {
-                        return {
-                            setValue: jest.fn(),
-                            getValue: jest.fn()
-                        };
-                    })
-                },
-                contentPicker: true,
-                setUrl: jest.fn()
+            dialog = {
+                getContentElement: jest.fn(() => {
+                    return {
+                        setValue: jest.fn(),
+                        getValue: jest.fn()
+                    };
+                })
             };
+            contentPicker = true;
+            setUrl = jest.fn();
         });
 
         it('should fill url with contentPrefix and suffix', () => {
-            fillCKEditorPicker(picker, {path: '/yoloo'});
-            expect(picker.setUrl).toHaveBeenCalledWith(
+            fillCKEditorPicker(setUrl, dialog, contentPicker, {path: '/yoloo'});
+            expect(setUrl).toHaveBeenCalledWith(
                 '/cms/{mode}/{lang}/yoloo.html',
                 {}
             );
         });
 
         it('should fill url with filePrefix', () => {
-            picker.contentPicker = false;
-            fillCKEditorPicker(picker, {path: '/yoloo'});
-            expect(picker.setUrl).toHaveBeenCalledWith(
+            contentPicker = false;
+            fillCKEditorPicker(setUrl, dialog, contentPicker, {path: '/yoloo'});
+            expect(setUrl).toHaveBeenCalledWith(
                 '/files/{workspace}/yoloo',
                 {}
             );
@@ -109,7 +102,7 @@ describe('RichText utils', () => {
 
         it('should fill advTitle', () => {
             const setValueOfAdvTitle = jest.fn();
-            picker.dialog.getContentElement = jest.fn((_, id) => {
+            dialog.getContentElement = jest.fn((_, id) => {
                 if (id === 'advTitle') {
                     return {
                         setValue: setValueOfAdvTitle
@@ -122,13 +115,13 @@ describe('RichText utils', () => {
                 };
             });
 
-            fillCKEditorPicker(picker, {path: '/yoloo', name: 'success'});
+            fillCKEditorPicker(setUrl, dialog, contentPicker, {path: '/yoloo', name: 'success'});
             expect(setValueOfAdvTitle).toHaveBeenCalledWith('success');
         });
 
         it('should fill txtAlt', () => {
             const setValueOfAdvTitle = jest.fn();
-            picker.dialog.getContentElement = jest.fn((_, id) => {
+            dialog.getContentElement = jest.fn((_, id) => {
                 if (id === 'url') {
                     return;
                 }
@@ -145,7 +138,7 @@ describe('RichText utils', () => {
                 };
             });
 
-            fillCKEditorPicker(picker, {path: '/yoloo', name: 'success'});
+            fillCKEditorPicker(setUrl, dialog, contentPicker, {path: '/yoloo', name: 'success'});
             expect(setValueOfAdvTitle).toHaveBeenCalledWith('success');
         });
     });

--- a/src/javascript/SelectorTypes/RichText/RichText.utils.spec.js
+++ b/src/javascript/SelectorTypes/RichText/RichText.utils.spec.js
@@ -1,4 +1,4 @@
-import {buildPickerContext, fillCKEditorPicker} from './RichText.utils';
+import {getPickerValue, fillCKEditorPicker} from './RichText.utils';
 
 jest.mock('@jahia/ui-extender', () => {
     return {
@@ -28,12 +28,12 @@ describe('RichText utils', () => {
         });
 
         it('should always displayTree', () => {
-            const {pickerConfig} = buildPickerContext(picker);
+            const {pickerConfig} = getPickerValue(picker);
             expect(pickerConfig.displayTree).toBe(true);
         });
 
         it('should an empty currentValue when input is empty', () => {
-            const {currentValue} = buildPickerContext(picker);
+            const {currentValue} = getPickerValue(picker);
             expect(currentValue).toBe('');
         });
 
@@ -43,7 +43,7 @@ describe('RichText utils', () => {
                     getValue: () => '/cms/{mode}/{lang}/richTextEdition/toot/al/regal.html'
                 };
             });
-            const {currentValue} = buildPickerContext(picker);
+            const {currentValue} = getPickerValue(picker);
             expect(currentValue).toBe('/richTextEdition/toot/al/regal');
         });
 
@@ -53,7 +53,7 @@ describe('RichText utils', () => {
                     getValue: () => '/files/{workspace}/richTextEdition/toot/al/regal.html'
                 };
             });
-            const {currentValue} = buildPickerContext(picker);
+            const {currentValue} = getPickerValue(picker);
             expect(currentValue).toBe('/richTextEdition/toot/al/regal.html');
         });
 
@@ -67,7 +67,7 @@ describe('RichText utils', () => {
                     getValue: () => '/files/{workspace}/richTextEdition/toot/al/regal.html'
                 };
             });
-            const {currentValue} = buildPickerContext(picker);
+            const {currentValue} = getPickerValue(picker);
             expect(currentValue).toBe('/richTextEdition/toot/al/regal.html');
         });
     });

--- a/src/javascript/register.jsx
+++ b/src/javascript/register.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {registry} from '@jahia/ui-extender';
 import {registerActions} from './registerActions';
 import {Constants} from '~/ContentEditor.constants';
-import {ContentEditorApi} from './ContentEditorApi';
+import {ContentEditorApi, ContentPickerApi} from './ContentEditorApi';
 import {ContentEditorRoute} from './ContentEditorRoute/ContentEditorRoute';
 import {ContentEditorHistoryContextProvider} from '~/contexts';
 import {registerSelectorTypes} from '~/SelectorTypes';
@@ -22,7 +22,7 @@ export function register() {
 
     registry.add('app', 'content-editor-api', {
         targets: ['root:16.5'],
-        render: next => <ContentEditorApiContextProvider><ContentEditorApi/>{next}</ContentEditorApiContextProvider>
+        render: next => <ContentEditorApiContextProvider><ContentEditorApi/><ContentPickerApi/>{next}</ContentEditorApiContextProvider>
     });
 
     registerActions(registry);

--- a/src/javascript/shared/index.js
+++ b/src/javascript/shared/index.js
@@ -1,4 +1,5 @@
 export * from '../contexts/ContentEditor';
+export * from '../contexts/ContentEditorConfig';
 export * from '../contexts/ContentEditorApi';
 export * from '../contexts/ContentEditorSection';
 export * from '../utils';


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20448

## Description

Adds a new entry point in the CE api to call the picker (openPicker) so that it can be used in any other 3rd party integration, including richtext editors. Moved the code from RichText to this ContentPickerApi to open a picker based on the state.
The main issue was that a few parameters were taken from CE context (lang, uilang, multiple, editorContext.site), which cannot be used if we want to be able to use the picker outside of CE. Instead pass these paramters to the openPicker api and propagate props until where they are used.
Also cleaned RichText.utils to use proper parameters.
