### PR TITLE
BACKLOG-20431 : expose content editor components

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor.jsx
+++ b/src/javascript/ContentEditor/ContentEditor.jsx
@@ -18,16 +18,16 @@ export const ContentEditor = props => {
 
     return (
         <ContentEditorConfigContextProvider config={props}>
-            { mode === 'edit' && (
-            <ContentEditorContextProvider useFormDefinition={envProps.useFormDefinition || useEditFormDefinition}>
-                <Edit/>
-            </ContentEditorContextProvider>
-                )}
-            { mode === 'create' && (
-            <ContentEditorContextProvider useFormDefinition={envProps.useFormDefinition || useCreateFormDefinition}>
-                <Create/>
-            </ContentEditorContextProvider>
-                )}
+            {mode === 'edit' && (
+                <ContentEditorContextProvider useFormDefinition={envProps.useFormDefinition || useEditFormDefinition}>
+                    <Edit/>
+                </ContentEditorContextProvider>
+            )}
+            {mode === 'create' && (
+                <ContentEditorContextProvider useFormDefinition={envProps.useFormDefinition || useCreateFormDefinition}>
+                    <Create/>
+                </ContentEditorContextProvider>
+            )}
         </ContentEditorConfigContextProvider>
     );
 };

--- a/src/javascript/ContentEditor/EditPanel/EditPanelCompact.jsx
+++ b/src/javascript/ContentEditor/EditPanel/EditPanelCompact.jsx
@@ -31,7 +31,7 @@ const accentColorButtonProps = {
 };
 
 export const EditPanelCompact = ({title, createAnother}) => {
-    const {siteInfo, lang, mode} = useContentEditorContext();
+    const {mode} = useContentEditorContext();
     const contentEditorConfigContext = useContentEditorConfigContext();
     const {t} = useTranslation('content-editor');
 
@@ -50,7 +50,7 @@ export const EditPanelCompact = ({title, createAnother}) => {
                     <DisplayAction actionKey="content-editor/header/3dots" render={DotsButtonRenderer}/>
                 </div>
                 <div className={clsx('flexRow', styles.languageSwitcher)}>
-                    <EditPanelLanguageSwitcher lang={lang} siteInfo={siteInfo}/>
+                    <EditPanelLanguageSwitcher/>
                     <div className="flexFluid"/>
                     <HeaderBadges mode={mode}/>
                 </div>

--- a/src/javascript/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
+++ b/src/javascript/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
@@ -42,7 +42,7 @@ const DotsButtonRenderer = getButtonRenderer({
 });
 
 export const EditPanelHeader = ({title, isShowPublish, activeTab, setActiveTab}) => {
-    const {nodeData, nodeTypeName, nodeTypeDisplayName, mode, siteInfo, lang} = useContentEditorContext();
+    const {nodeData, nodeTypeName, nodeTypeDisplayName, mode} = useContentEditorContext();
 
     const backButton = (
         <DisplayAction actionKey="backButton" render={ButtonRendererNoLabel} buttonProps={{variant: 'outlined', icon: <ArrowLeft/>}}/>
@@ -86,7 +86,7 @@ export const EditPanelHeader = ({title, isShowPublish, activeTab, setActiveTab})
                 )}
                 toolbarLeft={(
                     <div className={styles.headerToolBar}>
-                        <EditPanelLanguageSwitcher lang={lang} siteInfo={siteInfo}/>
+                        <EditPanelLanguageSwitcher/>
 
                         <Separator variant="vertical" size="medium"/>
 

--- a/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
+++ b/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import {Dropdown, Edit, Language} from '@jahia/moonstone';
-import * as PropTypes from 'prop-types';
 import {useContentEditorConfigContext, useContentEditorContext} from '~/contexts';
 import styles from './EditPanelLanguageSwitcher.scss';
 import {getCapitalized, useSwitchLanguage} from '~/utils';
 import {useTranslation} from 'react-i18next';
 
-export const EditPanelLanguageSwitcher = ({siteInfo}) => {
+export const EditPanelLanguageSwitcher = () => {
     const {mode, lang: currentLanguage} = useContentEditorConfigContext();
-    const {i18nContext, nodeData} = useContentEditorContext();
+    const {i18nContext, nodeData, siteInfo} = useContentEditorContext();
     const switchLanguage = useSwitchLanguage();
     const {t} = useTranslation('content-editor');
     const labelPrefix = 'content-editor:label.contentEditor.header.languageSwitcher';
@@ -61,9 +60,5 @@ export const EditPanelLanguageSwitcher = ({siteInfo}) => {
             />
         </>
     );
-};
-
-EditPanelLanguageSwitcher.propTypes = {
-    siteInfo: PropTypes.object.isRequired
 };
 

--- a/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.spec.jsx
+++ b/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.spec.jsx
@@ -2,14 +2,21 @@ import React from 'react';
 import {shallowWithTheme} from '@jahia/test-framework';
 import {dsGenericTheme} from '@jahia/design-system-kit';
 import {EditPanelLanguageSwitcher} from './index';
-import {useFormikContext} from 'formik';
 
 jest.mock('~/contexts/ContentEditor/ContentEditor.context', () => {
     return {
         useContentEditorContext: () => ({
             i18nContext: {},
             setI18nContext: jest.fn(),
-            resetI18nContext: jest.fn()
+            resetI18nContext: jest.fn(),
+            siteInfo: {
+                languages: [
+                    {
+                        language: 'en',
+                        displayName: 'English'
+                    }
+                ]
+            }
         })
     };
 });
@@ -21,33 +28,11 @@ jest.mock('~/contexts/ContentEditorConfig/ContentEditorConfig.context', () => {
     };
 });
 
-jest.mock('formik');
-
 describe('EditPanelLanguageSwitcher', () => {
     let defaultProps;
-    let formik;
-
-    beforeEach(() => {
-        defaultProps = {
-            siteInfo: {
-                languages: [
-                    {
-                        language: 'en',
-                        displayName: 'English'
-                    }
-                ]
-            },
-            formik: {}
-        };
-        formik = {
-            values: {}
-        };
-        useFormikContext.mockReturnValue(formik);
-    });
-
     it('should NOT show language switcher with one language', () => {
         const cmp = shallowWithTheme(
-            <EditPanelLanguageSwitcher {...defaultProps}/>,
+            <EditPanelLanguageSwitcher/>,
             {},
             dsGenericTheme
         );
@@ -61,7 +46,7 @@ describe('EditPanelLanguageSwitcher', () => {
         });
 
         const cmp = shallowWithTheme(
-            <EditPanelLanguageSwitcher {...defaultProps}/>,
+            <EditPanelLanguageSwitcher/>,
             {},
             dsGenericTheme
         );

--- a/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.spec.jsx
+++ b/src/javascript/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.spec.jsx
@@ -2,6 +2,16 @@ import React from 'react';
 import {shallowWithTheme} from '@jahia/test-framework';
 import {dsGenericTheme} from '@jahia/design-system-kit';
 import {EditPanelLanguageSwitcher} from './index';
+import {useFormikContext} from 'formik';
+
+const siteInfo = {
+    languages: [
+        {
+            language: 'en',
+            displayName: 'English'
+        }
+    ]
+};
 
 jest.mock('~/contexts/ContentEditor/ContentEditor.context', () => {
     return {
@@ -9,17 +19,14 @@ jest.mock('~/contexts/ContentEditor/ContentEditor.context', () => {
             i18nContext: {},
             setI18nContext: jest.fn(),
             resetI18nContext: jest.fn(),
-            siteInfo: {
-                languages: [
-                    {
-                        language: 'en',
-                        displayName: 'English'
-                    }
-                ]
-            }
+            siteInfo,
+            formik: {}
         })
     };
 });
+
+jest.mock('formik');
+
 jest.mock('~/contexts/ContentEditorConfig/ContentEditorConfig.context', () => {
     return {
         useContentEditorConfigContext: () => ({
@@ -29,7 +36,10 @@ jest.mock('~/contexts/ContentEditorConfig/ContentEditorConfig.context', () => {
 });
 
 describe('EditPanelLanguageSwitcher', () => {
-    let defaultProps;
+    let formik;
+    beforeEach(() => {
+        useFormikContext.mockReturnValue(formik);
+    });
     it('should NOT show language switcher with one language', () => {
         const cmp = shallowWithTheme(
             <EditPanelLanguageSwitcher/>,
@@ -40,7 +50,7 @@ describe('EditPanelLanguageSwitcher', () => {
     });
 
     it('should show language switcher with more than one language', () => {
-        defaultProps.siteInfo.languages.push({
+        siteInfo.languages.push({
             language: 'fr',
             displayName: 'French'
         });

--- a/src/javascript/actions/jcontent/editContent/editContentAction.jsx
+++ b/src/javascript/actions/jcontent/editContent/editContentAction.jsx
@@ -7,11 +7,23 @@ import {Constants} from '~/ContentEditor.constants';
 import {useTranslation} from 'react-i18next';
 import {useContentEditorApiContext} from '~/contexts/ContentEditorApi/ContentEditorApi.context';
 
-export const EditContent = ({path, isModal, isFullscreen, editCallback, render: Render, loading: Loading, ...otherProps}) => {
+export const EditContent = ({
+    path,
+    isModal,
+    isFullscreen,
+    editCallback,
+    render: Render,
+    loading: Loading,
+    ...otherProps
+}) => {
     const {redirect} = useContentEditorHistory();
     useTranslation('content-editor');
     const api = useContentEditorApiContext();
-    const {language, uilang, site} = useSelector(state => ({language: state.language, site: state.site, uilang: state.uilang}));
+    const {language, uilang, site} = useSelector(state => ({
+        language: state.language,
+        site: state.site,
+        uilang: state.uilang
+    }));
     const res = useNodeChecks(
         {path: path, language: language},
         {...otherProps}
@@ -24,7 +36,15 @@ export const EditContent = ({path, isModal, isFullscreen, editCallback, render: 
     return (
         <Render {...otherProps}
                 isVisible={res.checksResult}
-                onClick={() => isModal ? api.edit(res.node.uuid, site, language, uilang, isFullscreen, editCallback) : redirect({language, mode: Constants.routes.baseEditRoute, uuid: res.node.uuid})}
+                onClick={() => isModal ? api.edit({
+                    uuid: res.node.uuid,
+                    site,
+                    lang: language,
+                    uilang,
+                    isFullscreen,
+                    editCallback,
+                    ...otherProps.editConfig
+                }) : redirect({language, mode: Constants.routes.baseEditRoute, uuid: res.node.uuid})}
         />
     );
 };

--- a/src/javascript/shared/index.js
+++ b/src/javascript/shared/index.js
@@ -1,2 +1,7 @@
 export * from '../contexts/ContentEditor';
 export * from '../contexts/ContentEditorApi';
+export * from '../contexts/ContentEditorSection';
+export * from '../utils';
+export * from '../actions/contenteditor/goBackAction';
+export * from '../editorTabs/EditPanelContent/FormBuilder';
+export * from '../ContentEditor/EditPanel/EditPanelLanguageSwitcher';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,10 +1479,10 @@
     mdi-material-ui "^5.10.0"
     recompose "^0.30.0"
 
-"@jahia/moonstone@^2.4.21":
-  version "2.4.21"
-  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-2.4.21.tgz#09c815ea7b6098f82aba9c75fb5a15d18d347678"
-  integrity sha512-m0gwokR2s+kwTnTOSLIP2GC6uW9gP7O7PlpxR34YWzv84FKU0WWYKNXPYx5x9KlM17e+szkqZLwYM9AXTuipRA==
+"@jahia/moonstone@^2.4.22":
+  version "2.4.24"
+  resolved "https://registry.yarnpkg.com/@jahia/moonstone/-/moonstone-2.4.24.tgz#537cbf595d608252206f96713d7d6482c2e72b66"
+  integrity sha512-M0kPZtabvg84JVE4TFXmJVG9PSXFISgpdPQ5sln/dIuu7jEdvXOUjxCR+WrxgOTaSzJwOsNMFPG0K8tqS091LQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     clsx "^1.1.1"


### PR DESCRIPTION
Expose various component to be able build a custom layout for Content Editor
Allow to provide a configuration to content editor action
Remove unused property from the site switcher
