### PR TITLE
BACKLOG-20514 : expose edit / create adapters + few NPE fixes

### DIFF
--- a/src/javascript/SelectorTypes/Text/Text.jsx
+++ b/src/javascript/SelectorTypes/Text/Text.jsx
@@ -20,7 +20,7 @@ export const Text = ({field, value, id, editorContext, onChange, onBlur}) => {
         }}/>
     };
 
-    const maxLength = field.selectorOptions.find(option => option.name === 'maxLength');
+    const maxLength = field.selectorOptions?.find(option => option.name === 'maxLength');
     return (
         <Input
             fullWidth

--- a/src/javascript/shared/index.js
+++ b/src/javascript/shared/index.js
@@ -5,3 +5,8 @@ export * from '../utils';
 export * from '../actions/contenteditor/goBackAction';
 export * from '../editorTabs/EditPanelContent/FormBuilder';
 export * from '../ContentEditor/EditPanel/EditPanelLanguageSwitcher';
+export {useFormDefinition} from '../contexts/ContentEditor/useFormDefinitions';
+export {EditFormQuery} from '../ContentEditor/edit.gql-queries';
+export {CreateFormQuery} from '../ContentEditor/create.gql-queries';
+export {adaptEditFormData} from '../ContentEditor/adaptEditFormData';
+export {adaptCreateFormData} from '../ContentEditor/adaptCreateFormData';

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
@@ -459,12 +459,12 @@ public class EditorFormServiceImpl implements EditorFormService {
     private String resolveMainSectionName(EditorFormFieldSet fieldSet) {
         String targetSectionName = fieldSet.getTarget().getSectionName() != null ? fieldSet.getTarget().getSectionName() : DEFAULT_SECTION;
         for (EditorFormField field : fieldSet.getEditorFormFields()) {
-            String sectionName = field.getTarget().getSectionName();
+            EditorFormFieldTarget sectionTarget = field.getTarget();
             // Keep in mind that it could be the case that targetSectionName name will not be the same as section name for all fields (based on previous code).
             // It is not clear where to put that field at that point. The concept itself is quite strange since intuition would suggest that a fieldset cannot be
             // in more than one section at a time. I preserved original behaviour here to not get into a lot of refactoring.
-            if (sectionName != null) {
-                targetSectionName = sectionName;
+            if (sectionTarget != null && sectionTarget.getSectionName() != null) {
+                targetSectionName = sectionTarget.getSectionName();
                 break;
             }
         }


### PR DESCRIPTION
Expose adapters and corresponding graphql queries
Fix 2 NPE:
- one in Text when the component is loaded 
- one in FieldSet when an override has no need to be moved to a different section