### PR TITLE
QA-14687: Exclude users and groups folder when recursing editorial link picker

### DIFF
--- a/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
@@ -15,7 +15,11 @@ export const PickerEditorialLinkQueryHandler = {
             treeParams.selectableTypes = ['jmix:mainResource'];
         }
 
-        treeParams.recursionTypesFilter = {multi: 'NONE', types: ['jmix:mainResource', 'jnt:contentFolder', 'jnt:page', 'jnt:folder', 'jnt:navMenuText']};
+        treeParams.recursionTypesFilter = {
+            multi: 'NONE',
+            types: ['jmix:mainResource', 'jnt:contentFolder', 'jnt:page', 'jnt:folder',
+                'jnt:navMenuText', 'jnt:usersFolder', 'jnt:groupsFolder']
+        };
 
         return treeParams;
     }

--- a/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
@@ -17,8 +17,15 @@ export const PickerEditorialLinkQueryHandler = {
 
         treeParams.recursionTypesFilter = {
             multi: 'NONE',
-            types: ['jmix:mainResource', 'jnt:contentFolder', 'jnt:page', 'jnt:folder',
-                'jnt:navMenuText', 'jnt:usersFolder', 'jnt:groupsFolder']
+            types: [
+                'jmix:mainResource',
+                'jnt:contentFolder',
+                'jnt:page',
+                'jnt:folder',
+                'jnt:navMenuText',
+                'jnt:usersFolder',
+                'jnt:groupsFolder'
+            ]
         };
 
         return treeParams;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14687

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

From testing with vicor-prod clone env, there's a slowdown when trying to link to server content from rich text which uses editorial link picker. Apparently this is because editorial link query uses `/sites/{site}` as root path and traverses both users and groups folder which is taking a lot of time.

Exclude these folders when recursing editorial link picker. I've looked into maybe adding these on the higher-level query handler classes (e.g. `PickerTreeQueryHandler`), but none of them actually traverses from `sites/{site}`. There should be no impact on other pickers, although not sure if it's a good idea to add this as an overridable default.

There's also a related PR in jcontent here: https://github.com/Jahia/jcontent/pull/680