### PR TITLE
QA-14693 force value update of i18n values for languages different fr…

### DIFF
--- a/src/javascript/utils/fields.utils.js
+++ b/src/javascript/utils/fields.utils.js
@@ -58,7 +58,7 @@ const _adaptDecimalValues = (fieldType, value) => {
     return fieldType === 'DECIMAL' || fieldType === 'DOUBLE' ? value && value.replace(',', '.') : value;
 };
 
-function updateValue({field, value, lang, nodeData, sections, mixinsToMutate, propsToSave, propsToDelete, propFieldNameMapping}) {
+function updateValue({field, value, lang, nodeData, sections, mixinsToMutate, propsToSave, propsToDelete, propFieldNameMapping, forceUpdate}) {
     if (value !== undefined && value !== null && value !== '') {
         const fieldType = field.requiredType;
 
@@ -73,7 +73,7 @@ function updateValue({field, value, lang, nodeData, sections, mixinsToMutate, pr
         }
 
         // Check if property has changed
-        if (propertyHasChanged(valueToSave, field, nodeData)) {
+        if (propertyHasChanged(valueToSave, field, nodeData) || forceUpdate) {
             const fieldSetName = getDynamicFieldSetNameOfField(sections, field);
 
             // Is not dynamic OR is dynamic and node have the mixin
@@ -132,6 +132,9 @@ export function getDataToMutate({nodeData, formValues, i18nContext, sections, la
                 Object.keys(i18nContext).filter(i18nLang => i18nLang !== lang && i18nLang !== 'shared' && i18nLang !== 'memo').forEach(i18nLang => {
                     const translatedValue = i18nContext[i18nLang].values[key];
                     if (typeof translatedValue !== 'undefined') {
+                        // This means there are updated values in other languages and we want to save them without relaying on propertyHasChanged()
+                        // as the value in i18nContext may be identical to value in current language as is the case when copy-to-language is used.
+                        const forceUpdate = true;
                         updateValue({
                             field,
                             value: translatedValue,
@@ -141,7 +144,8 @@ export function getDataToMutate({nodeData, formValues, i18nContext, sections, la
                             mixinsToMutate,
                             propsToSave,
                             propsToDelete,
-                            propFieldNameMapping
+                            propFieldNameMapping,
+                            forceUpdate
                         });
                     }
                 });


### PR DESCRIPTION
…om current

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14693

## Description

 Force value update of i18n values for languages different from current. In case of copy-to-language, values in i18nContext are the same as value on the node for current language as result it doesn't pass 'has changes' check.