### PR TITLE
QA-14687: Exclude users and groups folder when recursing editorial link picker

### DIFF
--- a/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/PickerEditorialLinkQueryHandler.jsx
@@ -15,7 +15,18 @@ export const PickerEditorialLinkQueryHandler = {
             treeParams.selectableTypes = ['jmix:mainResource'];
         }
 
-        treeParams.recursionTypesFilter = {multi: 'NONE', types: ['jmix:mainResource', 'jnt:contentFolder', 'jnt:page', 'jnt:folder', 'jnt:navMenuText']};
+        treeParams.recursionTypesFilter = {
+            multi: 'NONE',
+            types: [
+                'jmix:mainResource',
+                'jnt:contentFolder',
+                'jnt:page',
+                'jnt:folder',
+                'jnt:navMenuText',
+                'jnt:usersFolder',
+                'jnt:groupsFolder'
+            ]
+        };
 
         return treeParams;
     }


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14687

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

4.2.2 backport of https://github.com/Jahia/content-editor/pull/1525