### PR TITLE
QA-14639: Enforce natural/JCR sorting when opening editorial link picker

### DIFF
--- a/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/editorialLinkPicker.js
+++ b/src/javascript/SelectorTypes/Picker/configs/editorialLinkPicker/editorialLinkPicker.js
@@ -32,6 +32,7 @@ export const registerEditorialLinkPicker = registry => {
                 return (node?.primaryNodeType.name !== 'jnt:page' && hasContentParent) ? CONTENT : PAGES;
             },
             tableConfig: {
+                defaultSort: {orderBy: ''},
                 queryHandler: PickerEditorialLinkQueryHandler,
                 tableHeader: <EditorialLinkContentTypeSelector/>,
                 defaultViewType: Constants.tableView.type.PAGES,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14639


