### PR TITLE
BACKLOG-20464: Store current system name, if an i18n property has been updated before switching language

### DIFF
--- a/src/javascript/utils/fields.utils.js
+++ b/src/javascript/utils/fields.utils.js
@@ -132,7 +132,7 @@ export function getDataToMutate({nodeData, formValues, i18nContext, sections, la
                 Object.keys(i18nContext).filter(i18nLang => i18nLang !== lang && i18nLang !== 'shared' && i18nLang !== 'memo').forEach(i18nLang => {
                     const translatedValue = i18nContext[i18nLang].values[key];
                     if (typeof translatedValue !== 'undefined') {
-                        // This means there are updated values in other languages and we want to save them without relaying on propertyHasChanged()
+                        // This means there are updated values in other languages, and we want to save them without relaying on propertyHasChanged()
                         // as the value in i18nContext may be identical to value in current language as is the case when copy-to-language is used.
                         const forceUpdate = true;
                         updateValue({

--- a/src/javascript/utils/systemName.utils.js
+++ b/src/javascript/utils/systemName.utils.js
@@ -18,7 +18,7 @@ export const decodeSystemName = systemName => {
 };
 
 /**
- * JCR system name doesnt allow this characters: ['/', ':', '[', ']', '|', '*']
+ * JCR system name doesn't allow those characters: ['/', ':', '[', ']', '|', '*']
  * So we will encode them
  *
  * @param systemName the system name to be encode

--- a/src/javascript/utils/useSwitchLanguage.js
+++ b/src/javascript/utils/useSwitchLanguage.js
@@ -62,6 +62,12 @@ export const useSwitchLanguage = () => {
             };
 
             fillValues(formik.values, previousValue, fieldsObj, i18nValues, nonI18nValues, dynamicFieldSets);
+
+            if (Object.keys(i18nValues.values).length > 0 && Object.keys(nonI18nValues.values).length === 0) {
+                const systemName = Object.keys(formik.values).find(fieldname => fieldname.endsWith('systemName'));
+                nonI18nValues.values[systemName] = formik.values[systemName];
+            }
+
             const newValues = Object.keys(nonI18nValues.values).length > 0 ? {shared: nonI18nValues} : {};
 
             if (Object.keys(i18nValues.values).length > 0) {

--- a/tests/cypress/e2e/systemNameTest.cy.ts
+++ b/tests/cypress/e2e/systemNameTest.cy.ts
@@ -53,7 +53,7 @@ describe('System name test', () => {
         check();
     });
 
-    it('Create a page with a accented characters', function () {
+    it('Create a page with an accented characters', function () {
         const check = function () {
             pageComposer.refresh();
             cy.url({decode: true}).should('contain', 'eaoaeuéàöäèü');


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20464

## Description

When an i18n property is set use the current system name across all languages

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
