### PR TITLE
BACKLOG-17201: Persist 'create another' checkbox state

### DIFF
--- a/src/javascript/ContentEditor/Create.jsx
+++ b/src/javascript/ContentEditor/Create.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import {useNotifications} from '@jahia/react-material';
 import {Formik} from 'formik';
 import {EditPanel} from './EditPanel';
@@ -14,12 +14,8 @@ export const Create = () => {
     const client = useApolloClient();
     const {t} = useTranslation('content-editor');
     const contentEditorConfigContext = useContentEditorConfigContext();
-    const {nodeData, initialValues, title, i18nContext} = useContentEditorContext();
+    const {nodeData, initialValues, title, i18nContext, createAnother} = useContentEditorContext();
     const {sections} = useContentEditorSectionContext();
-    const createAnotherState = useState(false);
-    const createAnother = {
-        value: createAnotherState[0], set: createAnotherState[1]
-    };
 
     useEffect(() => {
         return () => {

--- a/src/javascript/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/contexts/ContentEditor/ContentEditor.context.js
@@ -28,6 +28,13 @@ export const ContentEditorContextProvider = ({useFormDefinition, children}) => {
             count: 1
         }
     });
+
+    // Persist 'create another' chekbox state during language switch
+    const createAnotherState = useState(false);
+    const createAnother = {
+        value: createAnotherState[0], set: createAnotherState[1]
+    };
+
     const resetI18nContext = useCallback(() => {
         setI18nContext(prev => ({
             memo: {
@@ -125,7 +132,8 @@ export const ContentEditorContextProvider = ({useFormDefinition, children}) => {
         i18nContext,
         setI18nContext,
         resetI18nContext,
-        usages
+        usages,
+        createAnother
     };
 
     return (

--- a/tests/cypress/e2e/createContent.cy.ts
+++ b/tests/cypress/e2e/createContent.cy.ts
@@ -110,4 +110,31 @@ describe('Create content tests', {retries: 10}, () => {
         // GetComponentByRole(Button, 'backButton').click()
         pageComposer.refresh().shouldContain('Cypress news title');
     });
+
+    it('keeps "create another" checkbox state after save', () => {
+        const contentEditor = pageComposer
+            .openCreateContent()
+            .getContentTypeSelector()
+            .searchForContentType('Simple Text')
+            .selectContentType('Simple text')
+            .create();
+        cy.get('#contenteditor-dialog-title')
+            .should('be.visible')
+            .and('contain', 'Create Simple text');
+
+        contentEditor.openSection('Options').get().find('input[type="text"]').clear().type('create-another-1');
+        contentEditor.closeSection('Options');
+        contentEditor.openSection('Content').get().find('input[name="jnt:text_text"]')
+            .type('Create another - test 1');
+        contentEditor.addAnotherContent();
+        contentEditor.save();
+
+        cy.get('#createAnother').should('have.attr', 'aria-checked', 'true');
+        contentEditor.openSection('Options').get().find('input[type="text"]').clear().type('create-another-2');
+        contentEditor.openSection('Content').get().find('input[type="text"]').type('Create another - test 2');
+        contentEditor.removeAnotherContent();
+        contentEditor.save();
+        pageComposer.refresh().shouldContain('Create another - test 1');
+        pageComposer.refresh().shouldContain('Create another - test 2');
+    });
 });

--- a/tests/cypress/e2e/createContentI18N.cy.ts
+++ b/tests/cypress/e2e/createContentI18N.cy.ts
@@ -113,4 +113,23 @@ describe('Create content tests in I18N site', () => {
         pageComposer.refresh().shouldContain('Cypress Work In Progress FR/EN Test');
         pageComposer.shouldContainWIPOverlay();
     });
+
+    it('keeps "create another" checkbox state when switching languages ', () => {
+        const contentEditor = pageComposer
+            .openCreateContent()
+            .getContentTypeSelector()
+            .searchForContentType('Rich Text')
+            .selectContentType('Rich text')
+            .create();
+        cy.get('#contenteditor-dialog-title')
+            .should('be.visible')
+            .and('contain', 'Create Rich text');
+
+        contentEditor.getLanguageSwitcher().selectLang('English');
+        contentEditor.addAnotherContent();
+        contentEditor.getLanguageSwitcher().selectLang('Français');
+        cy.get('#createAnother').should('have.attr', 'aria-checked', 'true');
+
+        contentEditor.cancel();
+    });
 });

--- a/tests/cypress/e2e/pickers/pdf.cy.ts
+++ b/tests/cypress/e2e/pickers/pdf.cy.ts
@@ -1,4 +1,5 @@
 import {JContent} from '../../page-object/jcontent';
+import {AccordionItem} from '../../page-object/accordionItem';
 
 describe('Picker - PDF', () => {
     const siteKey = 'digitall';
@@ -20,8 +21,10 @@ describe('Picker - PDF', () => {
         const contentEditor = jcontent.editComponentByText('CEOs of The Digital Roundtable');
         contentEditor.toggleOption('jdmix:fileAttachment', 'pdfVersion');
         const picker = contentEditor.getPickerField('jdmix:fileAttachment_pdfVersion').open();
-        picker.getAccordionItem('picker-media').expandTreeItem('images');
-        picker.getAccordionItem('picker-media').getTreeItem('pdf').click();
+        const pagesAccordion: AccordionItem = picker.getAccordionItem('picker-media');
+        pagesAccordion.getHeader().should('be.visible');
+        pagesAccordion.expandTreeItem('images');
+        pagesAccordion.getTreeItem('pdf').click();
         picker.verifyResultsLength(2);
         picker.getAccordionItem('picker-media').getTreeItem('backgrounds').click();
         picker.assertHasNoTable();
@@ -31,11 +34,12 @@ describe('Picker - PDF', () => {
         const contentEditor = jcontent.editComponentByText('CEOs of The Digital Roundtable');
         contentEditor.toggleOption('jdmix:fileAttachment', 'pdfVersion');
         const picker = contentEditor.getPickerField('jdmix:fileAttachment_pdfVersion').open();
-        picker.getAccordionItem('picker-media').expandTreeItem('images');
-        picker.getAccordionItem('picker-media').getTreeItem('pdf').click();
-        picker.verifyResultsLength(2);
-        picker.search('digitall');
+        picker.get().find('header p').contains('Select a PDF file').should('be.visible');
+        const pagesAccordion: AccordionItem = picker.getAccordionItem('picker-media');
+        pagesAccordion.getHeader().should('be.visible');
+
         picker.switchSearchContext('Digitall');
+        picker.search('digitall');
         picker.verifyResultsLength(1);
     });
 });

--- a/tests/cypress/e2e/pickers/pickerMultiple.cy.ts
+++ b/tests/cypress/e2e/pickers/pickerMultiple.cy.ts
@@ -38,6 +38,8 @@ describe('Picker tests - multiple', () => {
         cy.log(`select the first ${numRows} elements`);
         expect(numRows).gte(1); // Need at least one for testing removal
         picker.getTable().selectItems(numRows);
+        cy.get('[data-cm-role="selection-table-collapse-button"] span')
+            .should('be.visible').and('contain', `${numRows} items selected`);
         picker.select();
 
         cy.log('verify selected is listed in CE modal/page');

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -2,7 +2,6 @@ import {
     BasePage,
     Button,
     Collapsible,
-    Dropdown,
     getComponentByAttr,
     getComponentByRole,
     getComponentBySelector,
@@ -10,9 +9,10 @@ import {
 } from '@jahia/cypress';
 import {ComponentType} from '@jahia/cypress/src/page-object/baseComponent';
 import {Field, PickerField, RichTextField, SmallTextField} from './fields';
+import {LanguageSwitcher} from '@jahia/design-system-kit';
 
 export class ContentEditor extends BasePage {
-    languageSwitcher: Dropdown;
+    languageSwitcher: LanguageSwitcher;
 
     openSection(sectionName: string) {
         return getComponentBySelector(Collapsible, `[data-sel-content-editor-fields-group="${sectionName}"]`).expand();
@@ -45,11 +45,11 @@ export class ContentEditor extends BasePage {
     }
 
     addAnotherContent() {
-        cy.get('#createAnother').check();
+        cy.get('#createAnother').check().should('have.attr', 'aria-checked', 'true');
     }
 
     removeAnotherContent() {
-        cy.get('#createAnother').uncheck();
+        cy.get('#createAnother').uncheck().should('have.attr', 'aria-checked', 'false');
     }
 
     activateWorkInProgressMode(language?: string) {
@@ -78,9 +78,9 @@ export class ContentEditor extends BasePage {
         }
     }
 
-    getLanguageSwitcher(): Dropdown {
+    getLanguageSwitcher(): LanguageSwitcher {
         if (!this.languageSwitcher) {
-            this.languageSwitcher = getComponentBySelector(Dropdown, '#contenteditor-dialog-title [data-cm-role="language-switcher"]');
+            this.languageSwitcher = getComponentBySelector(LanguageSwitcher, '#contenteditor-dialog-title [data-cm-role="language-switcher"]');
         }
 
         return this.languageSwitcher;

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -9,7 +9,7 @@ import {
 } from '@jahia/cypress';
 import {ComponentType} from '@jahia/cypress/src/page-object/baseComponent';
 import {Field, PickerField, RichTextField, SmallTextField} from './fields';
-import {LanguageSwitcher} from '@jahia/design-system-kit';
+import {LanguageSwitcher} from './languageSwitcher';
 
 export class ContentEditor extends BasePage {
     languageSwitcher: LanguageSwitcher;

--- a/tests/cypress/page-object/languageSwitcher.ts
+++ b/tests/cypress/page-object/languageSwitcher.ts
@@ -1,0 +1,9 @@
+import {Dropdown} from '@jahia/cypress';
+
+export class LanguageSwitcher extends Dropdown {
+    selectLang(displayLang: string) {
+        this.select(displayLang).get()
+            .find(`span[title="${displayLang}"]`)
+            .should('be.visible');
+    }
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17201

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Move `createAnother` state to content-editor context to persist when switching languages during create.