### PR TITLE
BACKLOG-20659: Fully reset i18n context

### DIFF
--- a/src/javascript/actions/contenteditor/create/createAction.js
+++ b/src/javascript/actions/contenteditor/create/createAction.js
@@ -43,16 +43,16 @@ const Create = ({createAnother, render: Render, loading: Loading, ...otherProps}
                     if (createAnother) {
                         // Refetch only to generate a new valid system name
                         refetchFormData().then(() => {
-                            resetI18nContext();
                             formik.resetForm({values: initialValues});
+                            resetI18nContext();
                             setClicked(false);
                             if (envProps.onCreateAnother) {
                                 envProps.onCreateAnother();
                             }
                         });
                     } else {
-                        resetI18nContext();
                         formik.resetForm({values: formik.values});
+                        resetI18nContext();
                         if (envProps.onSavedCallback) {
                             envProps.onSavedCallback(data);
                         }
@@ -85,3 +85,4 @@ Create.propTypes = {
 export const createAction = {
     component: Create
 };
+

--- a/src/javascript/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/contexts/ContentEditor/ContentEditor.context.js
@@ -31,7 +31,6 @@ export const ContentEditorContextProvider = ({useFormDefinition, children}) => {
     const resetI18nContext = useCallback(() => {
         setI18nContext(prev => ({
             memo: {
-                ...prev.memo,
                 count: (prev.memo?.count || 0) + 1
             }
         }));


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20659

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Reverted PR change from BACKLOG-17202 as it's causing regression.

As alternative solution, trying to fully reset i18n context. I'm not sure if there's some reasoning behind keeping previous values on i18n reset (I'm hoping cypress test results will tell me...)