### PR TITLE
BACKLOG-20726: Fix Apollo crashing errors due to missing cache id for…

### DIFF
--- a/src/javascript/Edit/EditForm.gql-queries.js
+++ b/src/javascript/Edit/EditForm.gql-queries.js
@@ -28,6 +28,7 @@ const NodeDataFragment = {
                     "jmix:mainResource"
                 ]})
                 displayableNode {
+                    ...NodeCacheRequiredFields
                     path
                     isFolder:isNodeType(type: {multi: ANY, types: ["jnt:contentFolder", "jnt:folder"]})
                 }


### PR DESCRIPTION
… displayableNode graphQL field usage.