### PR TITLE
BACKLOG-20731: Push contentEditor location state if CE not opened yet

### DIFF
--- a/src/javascript/ContentEditorApi/ContentEditorApi.jsx
+++ b/src/javascript/ContentEditorApi/ContentEditorApi.jsx
@@ -81,7 +81,11 @@ export const ContentEditorApi = () => {
         if (loaded.current) {
             const currentEncodedLocation = rison.encode({search: history.location.search, hash: history.location.hash});
             if (currentEncodedLocation !== locationFromState) {
-                history.replace(rison.decode(locationFromState));
+                if (currentEncodedLocation.includes('contentEditor:')) {
+                    history.replace(rison.decode(locationFromState));
+                } else {
+                    history.push(rison.decode(locationFromState));
+                }
             }
         }
     }, [history, locationFromState]);

--- a/src/javascript/ContentEditorApi/OnCloseConfirmationDialog.jsx
+++ b/src/javascript/ContentEditorApi/OnCloseConfirmationDialog.jsx
@@ -5,6 +5,20 @@ import {useFormikContext} from 'formik';
 import {useContentEditorContext} from '~/contexts/ContentEditor';
 import {isDirty} from '~/utils';
 
+import rison from 'rison-node';
+import {useLocation} from 'react-router-dom';
+
+function decode(hash) {
+    let values = {};
+    try {
+        values = hash ? rison.decode_uri(hash.substring(1)) : {};
+    } catch {
+        //
+    }
+
+    return values;
+}
+
 export const OnCloseConfirmationDialog = ({deleteEditorConfig, openDialog}) => {
     const [confirmationConfig, setConfirmationConfig] = useState(false);
     const formik = useFormikContext();
@@ -21,6 +35,20 @@ export const OnCloseConfirmationDialog = ({deleteEditorConfig, openDialog}) => {
             }
         };
     });
+
+    const location = useLocation();
+    useEffect(() => {
+        // Read hash to set/unset editors
+        const {contentEditor} = decode(location.hash);
+        if (contentEditor === undefined) {
+            if (dirty) {
+                formik.validateForm();
+                setConfirmationConfig(true);
+            } else {
+                deleteEditorConfig();
+            }
+        }
+    }, [deleteEditorConfig, location.hash]);
 
     return confirmationConfig && (
         <CloseConfirmationDialog

--- a/src/javascript/ContentEditorApi/OnCloseConfirmationDialog.jsx
+++ b/src/javascript/ContentEditorApi/OnCloseConfirmationDialog.jsx
@@ -48,7 +48,7 @@ export const OnCloseConfirmationDialog = ({deleteEditorConfig, openDialog}) => {
                 deleteEditorConfig();
             }
         }
-    }, [deleteEditorConfig, location.hash]);
+    }, [deleteEditorConfig, dirty, formik, location.hash]);
 
     return confirmationConfig && (
         <CloseConfirmationDialog


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20731

## Description

Push contentEditor location state if CE not opened yet otherwise replace. 
Add location.hash useEffect onConfirmationDialog


