### PR TITLE
BACKLOG-20268: Allow handling of onclick prop from Edit action

### DIFF
--- a/src/javascript/actions/jcontent/editContent/editContentAction.jsx
+++ b/src/javascript/actions/jcontent/editContent/editContentAction.jsx
@@ -36,15 +36,18 @@ export const EditContent = ({
     return (
         <Render {...otherProps}
                 isVisible={res.checksResult}
-                onClick={() => isModal ? api.edit({
-                    uuid: res.node.uuid,
-                    site,
-                    lang: language,
-                    uilang,
-                    isFullscreen,
-                    editCallback,
-                    ...otherProps.editConfig
-                }) : redirect({language, mode: Constants.routes.baseEditRoute, uuid: res.node.uuid})}
+                onClick={() => {
+                    otherProps.onClick && otherProps.onClick();
+                    isModal ? api.edit({
+                        uuid: res.node.uuid,
+                        site,
+                        lang: language,
+                        uilang,
+                        isFullscreen,
+                        editCallback,
+                        ...otherProps.editConfig
+                    }) : redirect({language, mode: Constants.routes.baseEditRoute, uuid: res.node.uuid})
+                }}
         />
     );
 };

--- a/src/javascript/actions/jcontent/editContent/editContentAction.jsx
+++ b/src/javascript/actions/jcontent/editContent/editContentAction.jsx
@@ -37,8 +37,11 @@ export const EditContent = ({
         <Render {...otherProps}
                 isVisible={res.checksResult}
                 onClick={() => {
-                    otherProps.onClick && otherProps.onClick();
-                    isModal ? api.edit({
+                    if (otherProps.onClick) {
+                        otherProps.onClick();
+                    }
+
+                    return isModal ? api.edit({
                         uuid: res.node.uuid,
                         site,
                         lang: language,
@@ -46,7 +49,7 @@ export const EditContent = ({
                         isFullscreen,
                         editCallback,
                         ...otherProps.editConfig
-                    }) : redirect({language, mode: Constants.routes.baseEditRoute, uuid: res.node.uuid})
+                    }) : redirect({language, mode: Constants.routes.baseEditRoute, uuid: res.node.uuid});
                 }}
         />
     );


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20268

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

From this issue: https://github.com/Jahia/jcontent/pull/789#issuecomment-1526790119

Need to be able to dismiss links modal when clicking the edit action. Call any onclick handlers before opening edit modal.
