### PR TITLE
BACKLOG-20393: Add create actions to new rootContentActions target

### DIFF
--- a/src/javascript/actions/registerCreateActions.js
+++ b/src/javascript/actions/registerCreateActions.js
@@ -23,7 +23,7 @@ export const registerCreateActions = registry => {
     if (booleanValue(contextJsParameters.config.jcontent?.showPageComposer)) {
         registry.addOrReplace('action', 'createPage', createContentAction, {
             buttonIcon: <AddCircle/>,
-            targets: ['createMenuActions:-2', 'contentActions:-2', 'headerPrimaryActions:1'],
+            targets: ['createMenuActions:-2', 'contentActions:-2', 'rootContentActions:-2', 'headerPrimaryActions:1'],
             showOnNodeTypes: ['jnt:page', 'jnt:navMenuText', 'jnt:virtualsite'],
             requiredPermission: ['jcr:addChildNodes'],
             nodeTypes: ['jnt:page'],
@@ -40,7 +40,7 @@ export const registerCreateActions = registry => {
         registry.add('action', 'createNavMenuItemMenu', registry.get('action', 'menuAction'), {
             buttonIcon: <AddCircle/>,
             buttonLabel: 'content-editor:label.contentEditor.CMMActions.createNewContent.newMenu',
-            targets: ['createMenuActions:-1', 'contentActions:-1'],
+            targets: ['createMenuActions:-1', 'contentActions:-1', 'rootContentActions:-1'],
             menuTarget: 'createNavMenuItemMenu',
             isMenuPreload: true
         });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20393
https://jira.jahia.org/browse/BACKLOG-20964
https://jira.jahia.org/browse/BACKLOG-20966

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add these actions to the new `rootContentActions` target in jcontent

Related jcontent PR: https://github.com/Jahia/jcontent/pull/804