### PR TITLE
BACKLOG-20548: Only display Content section in CE for categories

### DIFF
--- a/src/javascript/editorTabs/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.jsx
+++ b/src/javascript/editorTabs/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.jsx
@@ -83,7 +83,7 @@ export const AdvancedOptionsNavigation = ({activeOption, setActiveOption}) => {
     }
 
     return (
-        <div className={styles.container}>
+        <div data-sel-role="advanced-options-nav" className={styles.container}>
             <ul>
                 <DisplayActions activeOption={activeOption}
                                 setActiveOption={setActiveOption}

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_category.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_category.json
@@ -1,5 +1,9 @@
 {
   "nodeType": "jnt:category",
   "priority": 1.0,
-  "hasPreview": false
+  "hasPreview": false,
+  "sections": [
+    {"name":  "content", "expanded": true},
+    {"name":  "seo", "hide": true}
+  ]
 }

--- a/tests/cypress/e2e/categories.cy.ts
+++ b/tests/cypress/e2e/categories.cy.ts
@@ -1,0 +1,42 @@
+import gql from 'graphql-tag';
+import {BaseComponent, Button, getComponentByRole} from '@jahia/cypress';
+
+describe('Category tests', () => {
+    const getNodeId = gql`
+        query getNodeId($path: String!) {
+            jcr {
+                nodeByPath(path: $path) {
+                    uuid
+                }   
+            }
+        }`;
+
+    beforeEach(() => {
+        cy.login(); // Edit in chief
+        const path = '/sites/systemsite/categories/annual-filings';
+        cy.apollo({query: getNodeId, variables: {path}})
+            .its('data.jcr.nodeByPath.uuid').as('nodeId')
+            .should('not.be.empty', '@nodeId');
+        cy.get('@nodeId').then(nodeId => cy.visit(`/jahia/content-editor/en/edit/${nodeId}`));
+    });
+
+    it('Category only displays Content section in edit', () => {
+        const sectionAttr = 'data-sel-content-editor-fields-group';
+        cy.get(`[${sectionAttr}]`)
+            .should('have.length', 1)
+            .and('have.attr', sectionAttr, 'Content');
+    });
+
+    it('Displays limited advanced options', () => {
+        getComponentByRole(BaseComponent, 'tab-advanced-options')
+            .get().click()
+            .should('have.class', 'moonstone-selected');
+
+        const advOptions = ['Technical information', 'Live roles', 'Edit roles', 'Usages', 'History'];
+        cy.get('[data-sel-role="advanced-options-nav"] li')
+            .should('have.length', advOptions.length)
+            .and(elems => {
+                advOptions.forEach(opt => expect(elems).to.contain(opt));
+            });
+    });
+});


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20548

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Use overrides to only display Content section (hide seo);
- Add cypress test:
  - Content section only visible for categories
  - Only display certain items in advanced options (see https://github.com/Jahia/jahia-private/pull/1608 )
