### PR TITLE
BACKLOG-20547: Register actions for jnt:category on use showCatMan flag to register Edit in headerPrimary

### DIFF
--- a/src/javascript/actions/registerCreateActions.js
+++ b/src/javascript/actions/registerCreateActions.js
@@ -13,7 +13,7 @@ export const registerCreateActions = registry => {
         buttonLabel:
             'content-editor:label.contentEditor.CMMActions.createNewContent.menu',
         targets: ['createMenuActions:3', 'contentActions:3', 'headerPrimaryActions:1'],
-        showOnNodeTypes: ['jnt:contentFolder', 'jnt:content'],
+        showOnNodeTypes: ['jnt:contentFolder', 'jnt:content', 'jnt:category'],
         hideOnNodeTypes: ['jnt:navMenuText', 'jnt:page'],
         requiredPermission: ['jcr:addChildNodes'],
         isModal: true,

--- a/src/javascript/actions/registerEditActions.js
+++ b/src/javascript/actions/registerEditActions.js
@@ -10,12 +10,13 @@ import {booleanValue} from '~/SelectorTypes/Picker/Picker.utils';
 
 export const registerEditActions = actionsRegistry => {
     const showPageComposer = booleanValue(contextJsParameters.config.jcontent?.showPageComposer);
+    const showCatMan = booleanValue(contextJsParameters.config.jcontent?.showCatMan);
 
     // Edit action button in JContent; need separate actions for content and pages
     actionsRegistry.add('action', 'edit', editContentAction, {
         buttonIcon: <Edit/>,
         buttonLabel: 'content-editor:label.contentEditor.edit.contentEdit',
-        targets: showPageComposer ? ['contentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1'] : ['contentActions:2', 'narrowHeaderMenu:1'],
+        targets: showPageComposer || showCatMan ? ['contentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1'] : ['contentActions:2', 'narrowHeaderMenu:1'],
         hideOnNodeTypes: ['jnt:virtualsite', 'jnt:page'], // For edit content
         requiredSitePermission: ['editAction'],
         getDisplayName: true,

--- a/src/main/resources/configs/contentEditor.jsp
+++ b/src/main/resources/configs/contentEditor.jsp
@@ -5,4 +5,4 @@
 contextJsParameters.config.wip="<%= settingsBean.getString("wip.link", "https://academy.jahia.com/documentation/enduser/jahia/8/authoring-content-in-jahia/using-content-editor/understanding-work-in-progress-content")%>";
 contextJsParameters.config.maxNameSize=<%= settingsBean.getMaxNameSize() %>;
 contextJsParameters.config.defaultSynchronizeNameWithTitle=<%= settingsBean.getString("jahia.ui.contentTab.defaultSynchronizeNameWithTitle", "true") %>;
-    contextJsParameters.config.contentEditor = <%= new JSONObject(BundleUtils.getOsgiService(ConfigService.class, null).getConfig("org.jahia.modules.contentEditor").getRawProperties()).toString() %>;
+contextJsParameters.config.contentEditor = <%= new JSONObject(BundleUtils.getOsgiService(ConfigService.class, null).getConfig("org.jahia.modules.contentEditor").getRawProperties()).toString() %>;


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20547

## Description

Modify actions to work with new Category Manager

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
