### PR TITLE
QA-14633: Use equals comparison for validating choicelist values

### DIFF
--- a/src/javascript/ContentEditor.constants.js
+++ b/src/javascript/ContentEditor.constants.js
@@ -16,6 +16,11 @@ export const Constants = {
         },
         editTab: 'EDIT'
     },
+    field: {
+        selectorType: {
+            CHOICELIST: 'Choicelist'
+        }
+    },
     supportedLocales: ['en', 'fr', 'de'],
     defaultLocale: 'en',
     routes: {

--- a/src/javascript/validation/validate.spec.js
+++ b/src/javascript/validation/validate.spec.js
@@ -586,6 +586,36 @@ describe('validate', () => {
                 field4: undefined
             });
         });
+
+        it('should do equals comparison for choicelist values', () => {
+            const {sections} = buildSections({
+                requiredType: 'STRING',
+                selectorType: Constants.field.selectorType.CHOICELIST,
+                valueConstraints: [
+                    {value: {string: '{"versions":["2.0.1","2.0.2","2.3.2-RELEASE"],"name":"account-button"}'}}
+                ]
+            });
+            const values = {
+                field1: '{"versions":["2.0.1","2.0.2","2.3.2-RELEASE"],"name":"account-button"}'
+            };
+
+            expect(validate(sections)(values)).toEqual({field1: undefined});
+        });
+
+        it('should do pattern matching comparison for non-choicelist values', () => {
+            const {sections} = buildSections({
+                requiredType: 'STRING',
+                // 'selectorType' not specified
+                valueConstraints: [
+                    {value: {string: '{"versions":["2.0.1","2.0.2","2.3.2-RELEASE"],"name":"account-button"}'}}
+                ]
+            });
+            const values = {
+                field1: '{"versions":["2.0.1","2.0.2","2.3.2-RELEASE"],"name":"account-button"}'
+            };
+
+            expect(validate(sections)(values)).toEqual({field1: 'invalidPattern'});
+        });
     });
 
     describe('max-length', () => {


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14633

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Do equals comparison instead of regex comparison for choicelist values
- Added test cases in validation.spec.js