### PR TITLE
QA-14376: Add cypress test for default template value, readonly

### DIFF
--- a/tests/cypress/e2e/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditorForm.cy.ts
@@ -1,23 +1,42 @@
 import {JContent} from '../page-object/jcontent';
-import {SmallTextField} from '../page-object/fields';
+import {Field, SmallTextField} from '../page-object/fields';
 import {Button, getComponentByRole} from '@jahia/cypress';
+import gql from "graphql-tag";
 
 describe('Content editor form', () => {
     let jcontent: JContent;
+    let siteKey = 'contentEditorSite';
 
     before(function () {
-        cy.executeGroovy('createSite.groovy', {SITEKEY: 'contentEditorSite'});
+        cy.executeGroovy('createSite.groovy', {SITEKEY: siteKey});
     });
 
     after(function () {
         cy.logout();
-        cy.executeGroovy('deleteSite.groovy', {SITEKEY: 'contentEditorSite'});
+        cy.executeGroovy('deleteSite.groovy', {SITEKEY: siteKey});
     });
 
     beforeEach(() => {
         cy.loginAndStoreSession();
         jcontent = JContent.visit('contentEditorSite', 'en', 'content-folders/contents');
     });
+
+    function setDefaultSiteTemplate(templateName) {
+        cy.apollo({
+            mutation: gql`
+                mutation setDefaultTemplate {
+                    jcr {
+                        mutateNode(pathOrId:"/sites/${siteKey}") {
+                            mutateProperty(name:"j:defaultTemplateName") {
+                                setValue(value:"${templateName}")
+                            }
+                        }
+                    }
+                }`
+        }).should(resp => {
+            expect(resp?.data?.jcr?.mutateNode.mutateProperty.setValue).to.be.true;
+        });
+    }
 
     it('Should display custom title label and error message', function () {
         const contentEditor = jcontent.createContent('testOverride');
@@ -38,4 +57,22 @@ describe('Content editor form', () => {
         cy.get('@categorizedContentFields').first().should('contain.text', 'category');
         cy.get('@categorizedContentFields').last().should('contain.text', 'subcategory');
     });
+
+    it('Should use site default template value', () => {
+        const contentTypeName = 'testDefaultTemplate';
+        const templateName = 'events';
+        const fieldName = 'cent:testDefaultTemplate_j:templateName';
+
+        cy.log('Set default template value for site');
+        setDefaultSiteTemplate(templateName);
+
+        cy.log('verify default template is shown in new component');
+        let contentEditor = jcontent.createContent(contentTypeName);
+        let field = contentEditor.getField(Field, fieldName);
+        field.get().find('[role="dropdown"]')
+            .should('contain', templateName)
+            .and('have.class', 'moonstone-disabled'); // read-only
+        contentEditor.create(); // no errors on create
+    });
+
 });

--- a/tests/cypress/e2e/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditorForm.cy.ts
@@ -1,11 +1,11 @@
 import {JContent} from '../page-object/jcontent';
 import {Field, SmallTextField} from '../page-object/fields';
 import {Button, getComponentByRole} from '@jahia/cypress';
-import gql from "graphql-tag";
+import gql from 'graphql-tag';
 
 describe('Content editor form', () => {
     let jcontent: JContent;
-    let siteKey = 'contentEditorSite';
+    const siteKey = 'contentEditorSite';
 
     before(function () {
         cy.executeGroovy('createSite.groovy', {SITEKEY: siteKey});
@@ -34,6 +34,7 @@ describe('Content editor form', () => {
                     }
                 }`
         }).should(resp => {
+            // eslint-disable-next-line  no-unused-expressions
             expect(resp?.data?.jcr?.mutateNode.mutateProperty.setValue).to.be.true;
         });
     }
@@ -67,12 +68,11 @@ describe('Content editor form', () => {
         setDefaultSiteTemplate(templateName);
 
         cy.log('verify default template is shown in new component');
-        let contentEditor = jcontent.createContent(contentTypeName);
-        let field = contentEditor.getField(Field, fieldName);
+        const contentEditor = jcontent.createContent(contentTypeName);
+        const field = contentEditor.getField(Field, fieldName);
         field.get().find('[role="dropdown"]')
             .should('contain', templateName)
-            .and('have.class', 'moonstone-disabled'); // read-only
-        contentEditor.create(); // no errors on create
+            .and('have.class', 'moonstone-disabled'); // Read-only
+        contentEditor.create(); // No errors on create
     });
-
 });

--- a/tests/cypress/fixtures/createSite.groovy
+++ b/tests/cypress/fixtures/createSite.groovy
@@ -8,7 +8,7 @@ if (sitesService.getSiteByKey("SITEKEY") == null) {
             siteKey("SITEKEY").
             serverName("localhost").
             title("SITEKEY").
-            modulesToDeploy(["content-editor-test-module"].toArray(new String[0])).
+            modulesToDeploy(new String[] {"content-editor-test-module"}).
             templateSet("dx-base-demo-templates").
             locale("en").build())
 }

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -52,7 +52,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>content-editor-test-module</artifactId>
     <name>Test module for content-editor</name>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (text-field-initializer) for content-editor cypress tests.</description>
 

--- a/tests/jahia-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/src/main/resources/META-INF/definitions.cnd
@@ -41,6 +41,11 @@
 [cent:testOverride] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent
  - jcr:title (string) < '^.{0,10}$'
 
+
+[cent:testDefaultTemplate] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent, jmix:hasTemplateNode
+- j:templateName (string,choicelist[templatesNode=pageTemplate]) mandatory nofulltext
+
+
 [cent:testRegExp] > jnt:content, jmix:basicContent
 - badge (string) mandatory < '[a-z0-9]+'
 - comment (string) mandatory < '^.{1,15}$'

--- a/tests/jahia-module/src/main/resources/META-INF/jahia-content-editor-forms/fieldsets/cent_testDefaultTemplate.json
+++ b/tests/jahia-module/src/main/resources/META-INF/jahia-content-editor-forms/fieldsets/cent_testDefaultTemplate.json
@@ -1,0 +1,10 @@
+{
+  "name": "cent:testDefaultTemplate",
+  "priority": 2.0,
+  "fields": [
+    {
+      "name": "j:templateName",
+      "readOnly": true
+    }
+  ]
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14376

Add priority value in json override to move `j:templateName` field from `jmix:hasTemplateNode` fieldSet to `cent:testDefaultTemplate` to be able to set readOnly
