### PR TITLE
Revert "BACKLOG-21238 Remove ce:manualOrdering field (#1665)"

### DIFF
--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/FormBuilder.spec.jsx
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/FormBuilder.spec.jsx
@@ -111,6 +111,18 @@ describe('FormBuilder component', () => {
         expect(cmp.children().length).toEqual(sectionContext.sections.length);
     });
 
+    it('should not display ordering section if not there', () => {
+        sectionContext.sections.push({
+            name: 'listOrdering',
+            displayName: 'Listordering',
+            expanded: false,
+            fieldSets: [
+            ]
+        });
+        const cmp = shallowWithTheme(<FormBuilder mode="create" formKey="dummy-uuid-create-2"/>, {}, dsGenericTheme).find('section');
+        expect(cmp.find('ChildrenSection').dive().find('Collapsible').exists()).toBeFalsy();
+    });
+
     it('should display ordering section if available', () => {
         sectionContext.sections.push({
             name: 'listOrdering',
@@ -120,7 +132,9 @@ describe('FormBuilder component', () => {
                 {
                     name: 'jmix:orderedList',
                     displayed: true,
-                    fields: []
+                    fields: [
+                        {name: 'jmix:orderedList_ce:manualOrdering'}
+                    ]
                 }
             ]
         });
@@ -138,7 +152,9 @@ describe('FormBuilder component', () => {
                 {
                     name: 'jmix:orderedList',
                     displayed: true,
-                    fields: []
+                    fields: [
+                        {name: 'jmix:orderedList_ce:manualOrdering'}
+                    ]
                 }
             ]
         });
@@ -153,10 +169,8 @@ describe('FormBuilder component', () => {
             expanded: false,
             fieldSets: [
                 {
-                    name: 'jmix:orderedList',
                     displayName: 'yo1',
                     displayed: true,
-                    readOnly: false,
                     fields: [
                         {name: 'field1', displayName: 'field 1'},
                         {name: 'field2', displayName: 'field 2'}

--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/AutomaticOrdering/AutomaticOrdering.spec.data.js
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/AutomaticOrdering/AutomaticOrdering.spec.data.js
@@ -8,6 +8,9 @@ export const listOrderingFieldSet = (fieldSetReadOnly, propsReadOnly) => ({
     readOnly: fieldSetReadOnly,
     fields: [
         {
+            name: 'jmix:orderedList_ce:manualOrdering'
+        },
+        {
             nodeType: 'jmix:orderedList',
             name: 'jmix:orderedList_ignoreCase',
             propertyName: 'ignoreCase',

--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ChildrenSection.jsx
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ChildrenSection.jsx
@@ -18,11 +18,13 @@ export const ChildrenSection = ({section, isExpanded, onClick}) => {
     const {t} = useTranslation('content-editor');
 
     const orderingFieldSet = section.fieldSets.find(fs => fs.name === 'jmix:orderedList');
-    const isAutomaticOrder = values[Constants.ordering.automaticOrdering.mixin];
+    const automaticallyOrderField = orderingFieldSet?.fields?.find(f => f.name === 'jmix:orderedList_firstField');
+    const manuallyOrderField = orderingFieldSet?.fields?.find(f => f.name === 'jmix:orderedList_ce:manualOrdering');
+    const isAutomaticOrder = automaticallyOrderField && values[Constants.ordering.automaticOrdering.mixin];
     const hasChildrenToReorder = values['Children::Order'] && values['Children::Order'].length > 0;
     const childrenFieldSets = section.fieldSets.filter(fieldSet => fieldSet.name !== 'jmix:orderedList');
 
-    if (!hasChildrenToReorder && childrenFieldSets.length === 0) {
+    if ((!manuallyOrderField || !hasChildrenToReorder) && !automaticallyOrderField && childrenFieldSets.length === 0) {
         return false;
     }
 
@@ -56,36 +58,38 @@ export const ChildrenSection = ({section, isExpanded, onClick}) => {
                     </div>
                 </div>
 
-                <div className="flexRow_nowrap">
-                    <Toggle
-                        classes={{
-                            root: fieldSetStyles.toggle
-                        }}
-                        data-sel-role-automatic-ordering={Constants.ordering.automaticOrdering.mixin}
-                        id={Constants.ordering.automaticOrdering.mixin}
-                        checked={isAutomaticOrder}
-                        readOnly={orderingFieldSet.readOnly}
-                        onChange={handleChange}
-                    />
-                    <div className="flexCol">
-                        <Typography component="label"
-                                    htmlFor={Constants.ordering.automaticOrdering.mixin}
-                                    className={fieldSetStyles.fieldSetTitle}
-                                    variant="subheading"
-                                    weight="bold"
-                        >
-                            {t('content-editor:label.contentEditor.section.listAndOrdering.automatic')}
-                        </Typography>
-                        <Typography component="label"
-                                    variant="caption"
-                                    className={clsx(fieldSetStyles.fieldSetDescription, fieldSetStyles.staticFieldSetDescription)}
-                        >
-                            {t('content-editor:label.contentEditor.section.listAndOrdering.description')}
-                        </Typography>
+                {automaticallyOrderField && (
+                    <div className="flexRow_nowrap">
+                        <Toggle
+                            classes={{
+                                root: fieldSetStyles.toggle
+                            }}
+                            data-sel-role-automatic-ordering={Constants.ordering.automaticOrdering.mixin}
+                            id={Constants.ordering.automaticOrdering.mixin}
+                            checked={isAutomaticOrder}
+                            readOnly={orderingFieldSet.readOnly || automaticallyOrderField.readOnly}
+                            onChange={handleChange}
+                        />
+                        <div className="flexCol">
+                            <Typography component="label"
+                                        htmlFor={Constants.ordering.automaticOrdering.mixin}
+                                        className={fieldSetStyles.fieldSetTitle}
+                                        variant="subheading"
+                                        weight="bold"
+                            >
+                                {t('content-editor:label.contentEditor.section.listAndOrdering.automatic')}
+                            </Typography>
+                            <Typography component="label"
+                                        variant="caption"
+                                        className={clsx(fieldSetStyles.fieldSetDescription, fieldSetStyles.staticFieldSetDescription)}
+                            >
+                                {t('content-editor:label.contentEditor.section.listAndOrdering.description')}
+                            </Typography>
+                        </div>
                     </div>
-                </div>
-                {!isAutomaticOrder && <ManualOrdering/>}
-                {isAutomaticOrder && <AutomaticOrdering orderingFieldSet={orderingFieldSet}/>}
+                )}
+                {!isAutomaticOrder && manuallyOrderField && <ManualOrdering/>}
+                {isAutomaticOrder && automaticallyOrderField && <AutomaticOrdering orderingFieldSet={orderingFieldSet}/>}
             </article>
             { childrenFieldSets?.map(fs => <FieldSet key={fs.name} fieldset={fs}/>) }
         </Collapsible>

--- a/src/javascript/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ChildrenSection.spec.jsx
+++ b/src/javascript/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ChildrenSection.spec.jsx
@@ -54,6 +54,18 @@ describe('Children section component', () => {
         expect(cmp.find('WithStyles(ToggleCmp)').props().readOnly).toBe(true);
     });
 
+    it('should not be able to switch automatic ordering', () => {
+        const fieldSet = listOrderingFieldSet(false, false);
+        fieldSet.fields = fieldSet.fields.filter(f => f.name === 'jmix:orderedList_ce:manualOrdering');
+        props.section = {fieldSets: [fieldSet]};
+
+        const cmp = shallowWithTheme(<ChildrenSection {...props}/>, {}, dsGenericTheme);
+
+        expect(cmp.find('WithStyles(ToggleCmp)').length).toBe(0);
+        expect(cmp.find('ManualOrdering').length).toBe(1);
+        expect(cmp.find('AutomaticOrdering').length).toBe(0);
+    });
+
     it('should display manual ordering', () => {
         props.section = {fieldSets: [listOrderingFieldSet(false, false)]};
 

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/nt_base_orderable.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/nt_base_orderable.json
@@ -7,7 +7,19 @@
       "name": "listOrdering",
       "fieldSets": [
         {
-          "name": "jmix:orderedList"
+          "name": "jmix:orderedList",
+          "fields": [
+            {
+              "rank": 0.0,
+              "name": "ce:manualOrdering",
+              "descriptionKey": "",
+              "requiredType": "String",
+              "selectorType": "Text",
+              "i18n": false,
+              "readOnly": false,
+              "multiple": false,
+              "mandatory": true
+            }]
         }]
     }
   ]

--- a/tests/cypress/e2e/listOrdering.cy.ts
+++ b/tests/cypress/e2e/listOrdering.cy.ts
@@ -1,11 +1,9 @@
 import {JContent} from '../page-object/jcontent';
 import {Collapsible, getComponentBySelector} from '@jahia/cypress';
-import {ContentEditor} from '../page-object';
 
 describe('Test list ordering', {retries: 0}, () => {
     const siteKey = 'digitall';
     let jcontent: JContent;
-    let contentEditor: ContentEditor;
 
     beforeEach(() => {
         cy.login(); // Edit in chief
@@ -20,23 +18,5 @@ describe('Test list ordering', {retries: 0}, () => {
         jcontent.switchToStructuredView();
         jcontent.editComponentByText('Events');
         getComponentBySelector(Collapsible, '[data-sel-content-editor-fields-group="Content list & ordering"]').get().should('exist');
-    });
-
-    it('Activates and deactivates automatic ordering', () => {
-        jcontent = JContent.visit(siteKey, 'en', 'pages/home');
-        jcontent.switchToStructuredView();
-        contentEditor = jcontent.editComponentByText('landing');
-        cy.get('p[data-sel-field-picker-name="true"]').should('exist');
-        cy.get('input[id="jmix:orderedList"]').click({force: true});
-        contentEditor.save();
-
-        contentEditor = jcontent.editComponentByText('landing');
-        cy.get('p[data-sel-field-picker-name="true"]').should('not.exist');
-        cy.get('div[data-sel-content-editor-field="jmix:orderedList_firstField"]').should('exist');
-        cy.get('input[id="jmix:orderedList"]').click({force: true});
-        contentEditor.save();
-
-        contentEditor = jcontent.editComponentByText('landing');
-        cy.get('p[data-sel-field-picker-name="true"]').should('exist');
     });
 });


### PR DESCRIPTION
This reverts commit 68b6ca3193e3707007d5b6460597e046e7473c5f.

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/BACKLOG-21238

## Description

Restore functionality