### PR TITLE
QA-14593: use jmix:droppableContent instead of jmix:editorialContent

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/forms/GqlEditorForms.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/forms/GqlEditorForms.java
@@ -127,7 +127,7 @@ public class GqlEditorForms {
 
         // Only jmix:editorialContent on jnt:contentFolder
         if (parentNode.isNodeType("jnt:contentFolder") && (nodeTypes == null || nodeTypes.isEmpty())) {
-            nodeTypes = Collections.singletonList("jmix:editorialContent");
+            nodeTypes = Collections.singletonList("jmix:droppableContent");
         }
         // check write access
         if (!parentNode.hasPermission("jcr:addChildNodes")) {

--- a/src/test/java/org/jahia/modules/contenteditor/utils/ContentEditorUtilsTest.java
+++ b/src/test/java/org/jahia/modules/contenteditor/utils/ContentEditorUtilsTest.java
@@ -153,7 +153,7 @@ public class ContentEditorUtilsTest extends AbstractJUnitTest {
         session.save();
         expectedResults.add("jnt:AllowedNodeTypesChildEditorial");
         expectedResults.add("jnt:AllowedNodeTypesChildEditorialMixinOnNode");
-        result = ContentEditorUtils.getAllowedNodeTypesAsChildNode(testedNode, null, false, true, Arrays.asList("jmix:droppableContent"));
+        result = ContentEditorUtils.getAllowedNodeTypesAsChildNode(testedNode, null, false, true, Arrays.asList("jmix:editorialContent"));
         validateResult(testdedNodeName, result, expectedResults);
         expectedResults.clear();
 

--- a/src/test/java/org/jahia/modules/contenteditor/utils/ContentEditorUtilsTest.java
+++ b/src/test/java/org/jahia/modules/contenteditor/utils/ContentEditorUtilsTest.java
@@ -153,7 +153,7 @@ public class ContentEditorUtilsTest extends AbstractJUnitTest {
         session.save();
         expectedResults.add("jnt:AllowedNodeTypesChildEditorial");
         expectedResults.add("jnt:AllowedNodeTypesChildEditorialMixinOnNode");
-        result = ContentEditorUtils.getAllowedNodeTypesAsChildNode(testedNode, null, false, true, Arrays.asList("jmix:editorialContent"));
+        result = ContentEditorUtils.getAllowedNodeTypesAsChildNode(testedNode, null, false, true, Arrays.asList("jmix:droppableContent"));
         validateResult(testdedNodeName, result, expectedResults);
         expectedResults.clear();
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14593


