### PR TITLE
QA-15049: Backport fix to 4_5_x. Dialog may not have field for alternate title (html5video plugin for example)

### DIFF
--- a/src/javascript/SelectorTypes/RichText/RichText.utils.js
+++ b/src/javascript/SelectorTypes/RichText/RichText.utils.js
@@ -19,9 +19,11 @@ export function fillCKEditorPicker(setUrl, dialog, contentPicker, pickerResult) 
 
     const altElementId = dialog.getName() === 'image2' ? 'alt' : 'txtAlt';
 
-    dialog
-        .getContentElement('info', eltId === 'url' ? 'advTitle' : altElementId)
-        .setValue(pickerResult.name);
+    const contentElement = dialog.getContentElement('info', eltId === 'url' ? 'advTitle' : altElementId);
+
+    if (contentElement !== undefined) {
+        contentElement.setValue(pickerResult.name);
+    }
 
     // Wrap path to build Jahia url.
     const pathWithEncodedFileName = pickerResult.path.replace(/\/([^/]+\.[^/?#]+)(\?|#|$)/, (_, fileName, suffix) => `/${encodeURIComponent(fileName)}${suffix}`);


### PR DESCRIPTION
…

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15049

## Description

Backport changes done in JContent