### PR TITLE
TECH-1573: Updated version and signature

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           module_id: content-editor
           testrail_project: Content Editor
+          timeout_minutes: 50
           tests_manifest: provisioning-manifest-snapshot.yml
           jahia_image: jahia/jahia-ee-dev:8.1-SNAPSHOT
           jahia_cluster_enabled: true

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -71,7 +71,7 @@ jobs:
     name: Integration Tests (Standalone)
     needs: build
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main
@@ -85,6 +85,7 @@ jobs:
         with:
           module_id: content-editor
           testrail_project: Content Editor
+          timeout_minutes: 50
           tests_manifest: provisioning-manifest-build.yml
           should_use_build_artifacts: true
           jahia_cluster_enabled: false

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -47,7 +47,7 @@ jobs:
     name: Integration Tests (Standalone)
     needs: build
     runs-on: self-hosted
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main
@@ -61,6 +61,7 @@ jobs:
         with:
           module_id: content-editor
           testrail_project: Content Editor
+          timeout_minutes: 50
           tests_manifest: provisioning-manifest-build.yml
           jahia_image: jahia/jahia-ee-dev:8.1-SNAPSHOT
           should_use_build_artifacts: true

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>content-editor</artifactId>
     <name>Jahia Content Editor</name>
-    <version>4.5.2-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Jahia Content Editor React extension.</description>
 
@@ -48,7 +48,7 @@
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-        <jahia-module-signature>MCwCFC14zrQFrhdlrI26e0IEXNTj5OY6AhRL9HwaSH2xVfqUuS03309iaYYBRg==</jahia-module-signature>
+        <jahia-module-signature>MC0CFHjPNb63yUw+TP17gskSFCdP8kCkAhUAlS2sXHTyjtFwLYiIRcC49gUwWiY=</jahia-module-signature>
         <jahia-depends>app-shell=2.7,graphql-dxm-provider=2.19.1,jcontent=2.9</jahia-depends>
         <jahia.plugin.version>6.5</jahia.plugin.version>
         <import-package>

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -52,7 +52,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>content-editor-test-module</artifactId>
     <name>Test module for content-editor</name>
-    <version>4.5.2-SNAPSHOT</version>
+    <version>4.6.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (text-field-initializer) for content-editor cypress tests.</description>
 


### PR DESCRIPTION
Due to the state of master, we were previously stuck into the 45x branch, now that this is cleaned, the next release of content-editor can be 4.6.0