### PR TITLE
BACKLOG-22904: Fix translation namespace for vanity url label

### DIFF
--- a/src/javascript/editorTabs/AdvancedOptions/VanityUrls/VanityUrls.jsx
+++ b/src/javascript/editorTabs/AdvancedOptions/VanityUrls/VanityUrls.jsx
@@ -34,8 +34,8 @@ export const VanityUrls = () => {
             </Typography>
             <Typography className={styles.item}>
                 {hasPermission ?
-                    t('jcontent:label.contentEditor.vanityTab.label') :
-                    t('jcontent:label.contentEditor.vanityTab.noPermissionLabel')}
+                    t('content-editor:label.contentEditor.vanityTab.label') :
+                    t('content-editor:label.contentEditor.vanityTab.noPermissionLabel')}
             </Typography>
             <div className={styles.item}>
                 <DisplayAction actionKey="vanityUrls"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22904

## Description

Follow-up to https://github.com/Jahia/content-editor/pull/1730 as backport to [QA-14983](https://jira.jahia.org/browse/QA-14983) from https://github.com/Jahia/jcontent/pull/1044.

Fix translation namespace from `jcontent` to `content-editor`
