### PR TITLE
QA-15247: Re-add missing check for empty selectorOptions

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
@@ -883,37 +883,39 @@ public class EditorFormServiceImpl implements EditorFormService {
         ExtendedPropertyDefinition propertyDefinition = editorFormField.getExtendedPropertyDefinition();
         if (propertyDefinition != null && propertyDefinition.getSelector() == SelectorType.CHOICELIST) {
             List<EditorFormProperty> selectorOptions = editorFormField.getSelectorOptions();
-            Map<String, ChoiceListInitializer> initializers = choiceListInitializerService.getInitializers();
+            if (!selectorOptions.isEmpty()) {
+                Map<String, ChoiceListInitializer> initializers = choiceListInitializerService.getInitializers();
 
-            Map<String, Object> context = new HashMap<>();
-            context.put("contextType", primaryNodeType);
-            context.put("contextNode", existingNode);
-            context.put("contextParent", parentNode);
-            context.putAll(extendContext);
-            List<ChoiceListValue> initialChoiceListValues = new ArrayList<>();
-            for (EditorFormProperty selectorProperty : selectorOptions) {
-                if (initializers.containsKey(selectorProperty.getName())) {
-                    initialChoiceListValues = initializers.get(selectorProperty.getName()).getChoiceListValues(propertyDefinition, selectorProperty.getValue(), initialChoiceListValues, locale, context);
-                }
-            }
-            List<EditorFormFieldValueConstraint> valueConstraints = new ArrayList<>();
-            for (ChoiceListValue choiceListValue : initialChoiceListValues) {
-                List<EditorFormProperty> propertyList = new ArrayList<>();
-                if (choiceListValue.getProperties() != null) {
-                    for (Map.Entry<String, Object> choiceListPropertyEntry : choiceListValue.getProperties().entrySet()) {
-                        propertyList.add(new EditorFormProperty(choiceListPropertyEntry.getKey(), choiceListPropertyEntry.getValue().toString()));
+                Map<String, Object> context = new HashMap<>();
+                context.put("contextType", primaryNodeType);
+                context.put("contextNode", existingNode);
+                context.put("contextParent", parentNode);
+                context.putAll(extendContext);
+                List<ChoiceListValue> initialChoiceListValues = new ArrayList<>();
+                for (EditorFormProperty selectorProperty : selectorOptions) {
+                    if (initializers.containsKey(selectorProperty.getName())) {
+                        initialChoiceListValues = initializers.get(selectorProperty.getName()).getChoiceListValues(propertyDefinition, selectorProperty.getValue(), initialChoiceListValues, locale, context);
                     }
                 }
-                try {
-                    valueConstraints.add(new EditorFormFieldValueConstraint(choiceListValue.getDisplayName(), null,
-                        new EditorFormFieldValue(choiceListValue.getValue()),
-                        propertyList
-                    ));
-                } catch (RepositoryException e) {
-                    logger.error("Error retrieving choice list value", e);
+                List<EditorFormFieldValueConstraint> valueConstraints = new ArrayList<>();
+                for (ChoiceListValue choiceListValue : initialChoiceListValues) {
+                    List<EditorFormProperty> propertyList = new ArrayList<>();
+                    if (choiceListValue.getProperties() != null) {
+                        for (Map.Entry<String, Object> choiceListPropertyEntry : choiceListValue.getProperties().entrySet()) {
+                            propertyList.add(new EditorFormProperty(choiceListPropertyEntry.getKey(), choiceListPropertyEntry.getValue().toString()));
+                        }
+                    }
+                    try {
+                        valueConstraints.add(new EditorFormFieldValueConstraint(choiceListValue.getDisplayName(), null,
+                            new EditorFormFieldValue(choiceListValue.getValue()),
+                            propertyList
+                        ));
+                    } catch (RepositoryException e) {
+                        logger.error("Error retrieving choice list value", e);
+                    }
                 }
+                return valueConstraints;
             }
-            return valueConstraints;
         }
         return editorFormField.getValueConstraints();
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15247

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fixing regression where the latest backport (https://github.com/Jahia/content-editor/pull/1745) override the check for empty selectorOptions (which was added here https://github.com/Jahia/content-editor/pull/1737/files?w=1#diff-00e38d6027e73906ae3862e36de5a9ad3f3f0d78bea54efbfc80c471b9e145d7R891) 

Re-add check for `!selectorOptions.isEmpty()`

