### PR TITLE
QA-15296: Fix regression for invalid target fieldset override

### DIFF
--- a/src/javascript/SelectorTypes/registerSelectorTypesOnChange.js
+++ b/src/javascript/SelectorTypes/registerSelectorTypesOnChange.js
@@ -12,9 +12,7 @@ export const registerSelectorTypesOnChange = registry => {
             const sections = onChangeContext.sections;
             const fields = getFields(sections);
             const dependentPropertiesFields = fields
-                .filter(f => f.selectorOptions
-                    .find(s => s.name === 'dependentProperties' && s.value.includes(field.propertyName))
-                );
+                .filter(f => f.selectorOptions?.find(s => s.name === 'dependentProperties' && s.value.includes(field.propertyName)));
 
             Promise.all(dependentPropertiesFields.map(dependentPropertiesField => {
                 const dependentProperties = dependentPropertiesField.selectorOptions.find(f => f.name === 'dependentProperties').value.split(',');

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
@@ -462,6 +462,10 @@ public class EditorFormServiceImpl implements EditorFormService {
                     for(EditorFormFieldSet formDefinitionFieldSet : sectionDefinition.getFieldSets()){
                         if(formFieldSet.getName().equals(formDefinitionFieldSet.getName())){
                             formFieldSet.setRank(formDefinitionFieldSet.getRank());
+                            String fieldSetDisplayName = resolveResourceKey(formDefinitionFieldSet.getDisplayName(), uiLocale, site);
+                            if (fieldSetDisplayName != null) {
+                                formFieldSet.setDisplayName(fieldSetDisplayName);
+                            }
                         }
                     }
                 }

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
@@ -674,15 +674,19 @@ public class EditorFormServiceImpl implements EditorFormService {
                 }
             }
 
-            // If the fieldset doesn't exist, we create it
             if (editorFormFieldSet == null) {
-                editorFormFieldSet = new EditorFormFieldSet();
-                editorFormFieldSet.setName(fieldTargetFieldSetName);
                 try {
+                    // Check first if target fieldset is valid node type
                     final ExtendedNodeType nodeType = NodeTypeRegistry.getInstance().getNodeType(fieldTargetFieldSetName, false);
                     if (nodeType == null) {
-                        logger.error("Node type {} not found for form {}", fieldTargetFieldSetName, formFieldSet.getName());
+                        logger.warn("Node type {} not found for form {}. Keeping {} field in {} fieldset.",
+                            fieldTargetFieldSetName, formFieldSet.getName(), editorFormField.getName(), formFieldSet.getName());
+                        // Put that thing back where it came from, or so help me
+                        formFieldSet.getEditorFormFields().add(editorFormField);
                     } else {
+                        // Fieldset doesn't exist, so we create it
+                        editorFormFieldSet = new EditorFormFieldSet();
+                        editorFormFieldSet.setName(fieldTargetFieldSetName);
                         editorFormFieldSet.setDisplayName(nodeType.getLabel(locale));
                         // and add it for the section
                         editorFormSection.getFieldSets().add(editorFormFieldSet);

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/impl/EditorFormServiceImpl.java
@@ -310,7 +310,7 @@ public class EditorFormServiceImpl implements EditorFormService {
                 resolvedSite = parentNode.getResolveSite();
             }
 
-            List<ExtendedNodeType> extendMixins = getExtendMixins(primaryNodeTypeName, resolvedSite);
+            List<ExtendedNodeType> extendMixins = getExtendMixins(primaryNodeType, resolvedSite);
             for (ExtendedNodeType extendMixinNodeType : extendMixins) {
                 if (processedNodeTypes.contains(extendMixinNodeType.getName())) {
                     // ignore already process node types
@@ -1029,25 +1029,21 @@ public class EditorFormServiceImpl implements EditorFormService {
         return JCRSessionFactory.getInstance().getCurrentUserSession(Constants.EDIT_WORKSPACE, locale, fallbackLocale);
     }
 
-    private List<ExtendedNodeType> getExtendMixins(String type, JCRSiteNode site) throws NoSuchNodeTypeException {
-        ArrayList<ExtendedNodeType> res = new ArrayList<ExtendedNodeType>();
-        Set<String> foundTypes = new HashSet<String>();
+    private List<ExtendedNodeType> getExtendMixins(ExtendedNodeType type, JCRSiteNode site) throws NoSuchNodeTypeException {
+        ArrayList<ExtendedNodeType> res = new ArrayList<>();
 
-        Set<String> installedModules = site != null && site.getPath().startsWith("/sites/") ? site.getInstalledModulesWithAllDependencies()
-            : null;
+        Set<String> installedModules = site != null && site.getPath().startsWith("/sites/") ? site.getInstalledModulesWithAllDependencies() : null;
 
         Map<ExtendedNodeType, Set<ExtendedNodeType>> m = NodeTypeRegistry.getInstance().getMixinExtensions();
 
-        ExtendedNodeType realType = NodeTypeRegistry.getInstance().getNodeType(type);
         for (ExtendedNodeType nodeType : m.keySet()) {
-            if (realType.isNodeType(nodeType.getName())) {
+            if (type.isNodeType(nodeType.getName())) {
                 for (ExtendedNodeType extension : m.get(nodeType)) {
-//                        ctx.put("contextType", realType);
-                    if (installedModules == null || extension.getTemplatePackage() == null ||
+                    if (installedModules == null ||
+                        extension.getTemplatePackage() == null ||
                         extension.getTemplatePackage().getModuleType().equalsIgnoreCase("system") ||
                         installedModules.contains(extension.getTemplatePackage().getId())) {
                         res.add(extension);
-                        foundTypes.add(extension.getName());
                     }
                 }
             }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15296

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

New feature https://github.com/Jahia/content-editor/pull/1763 added validation for invalid node types specified in the target fieldSet for a field override. As example, we have the following override on `jmix:tagged`:

```
{
  "name": "jmix:tagged",
  "priority": 1.0,
  "fields": [
    {
      "name": "j:tagList",
      "target": {
        "sectionName": "classification",
        "fieldSetName": "classification",
        "rank": 1
      }
    }
  ]
}
```

The `fieldSetName` value here is non-existent. In previous versions, we keep it in the current field set override (in this case, `j:tagList` is kept as part of `jmix:tagged` fieldset). With the recent change, the field is now removed and does not show up in the form.

Fix is to revert to previous behaviour and keep in the current form fieldset. Also downgraded logging to warn for compatibility. Also keeping current override definition even though the correct way is to specify "jmix:tagged" as target `fieldSetName` for any regression/compatibility check.