### PR TITLE
chore: Addressed incorrect artifact name in the sonar workflow

### DIFF
--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: ${{ matrix.supported_branches }}
-          build_artifacts: ''
+          build_artifacts: build-artifacts-${{ matrix.supported_branches }}
           github_pr_id: ${{github.event.number}}
           sonar_url: ${{ secrets.SONAR_URL }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This will address this error:

https://github.com/Jahia/content-editor/actions/runs/12703028619/job/35410166710

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```