### PR TITLE
BACKLOG-23452: Trim the date format when configured

### DIFF
--- a/src/javascript/SelectorTypes/DateTimePicker/DateTimePicker.jsx
+++ b/src/javascript/SelectorTypes/DateTimePicker/DateTimePicker.jsx
@@ -17,7 +17,7 @@ function getDateFormat(editorContext) {
     const allowedOverridesDateFormat = ['MM/DD/YYYY', 'DD/MM/YYYY'];
 
     // Read date format from config
-    const forceDateFormat = window.contextJsParameters?.config?.contentEditor?.forceDateFormat;
+    const forceDateFormat = window.contextJsParameters?.config?.contentEditor?.forceDateFormat?.trim();
     if (forceDateFormat && !allowedOverridesDateFormat.includes(forceDateFormat)) {
         console.warn(`forceDateFormat as been set to an invalid value (${forceDateFormat}). Please use one of the following values: ${allowedOverridesDateFormat.join(', ')}`);
     } else if (forceDateFormat) {

--- a/src/javascript/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
+++ b/src/javascript/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
@@ -126,6 +126,17 @@ describe('DateTimePicker component', () => {
         testDateFormat('de-DE', 'MM/DD/YYYY');
     });
 
+    it('should use the override date format when provided with leading/trailing spaces', () => {
+        window.contextJsParameters = {
+            config: {
+                contentEditor: {
+                    forceDateFormat: '  MM/DD/YYYY   '
+                }
+            }
+        };
+        testDateFormat('de-DE', 'MM/DD/YYYY');
+    });
+
     it('should NOT use the override date format when an invalid format is provided', () => {
         window.contextJsParameters = {
             config: {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/BACKLOG-23452

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

When a date format is configured in _Content Editor_ (`contentEditor.forceDateFormat` property), trim its value to loose restrictions on this property (as the value **must** be `'MM/DD/YYYY'` or  `'DD/MM/YYYY'`).
Similar to https://github.com/Jahia/jcontent/pull/1389 done for _Jcontent_.

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
