### PR TITLE
fix: allow clearing i18n fields from other languages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>content-editor</artifactId>
     <name>Jahia Content Editor</name>
-    <version>4.16.0-SNAPSHOT</version>
+    <version>4.15.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Jahia Content Editor React extension.</description>
 
@@ -48,7 +48,7 @@
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
-	<jahia-module-signature>MCwCFGYGGJXm3V3wSJ/D5JvFLTlWKFG6AhRWwmOhCqb+VFO6R3w3Gu3eydFpAA==</jahia-module-signature>
+	<jahia-module-signature>MCwCFHg1fBI6lWlzaKdGpyoNXmFt3ZhpAhQtlAsbqFjXUzjhUFi87Vmmt8t5Eg==</jahia-module-signature>
         <jahia-depends>app-shell=2.7,graphql-dxm-provider=2.22.0,jcontent=2.9</jahia-depends>
         <jahia.plugin.version>6.9</jahia.plugin.version>
         <import-package>

--- a/src/javascript/utils/fields.utils.js
+++ b/src/javascript/utils/fields.utils.js
@@ -93,18 +93,15 @@ function updateValue({field, value, lang, nodeData, sections, mixinsToMutate, pr
         }
     } else if (nodeData) {
         // Check if props existed before, to remove it
-        const nodeProperty = nodeData.properties.find(prop => prop.name === field.propertyName);
-        if (nodeProperty && nodeProperty[getValuePropName(field).name]) {
-            const fieldSetName = getDynamicFieldSetNameOfField(sections, field);
-            if (!fieldSetName ||
-                (fieldSetName &&
-                    !mixinsToMutate.mixinsToDelete.includes(fieldSetName) &&
-                    (hasNodeMixin(nodeData, fieldSetName) || mixinsToMutate.mixinsToAdd.includes(fieldSetName)))) {
-                propsToDelete.push({
-                    name: field.propertyName,
-                    language: lang
-                });
-            }
+        const fieldSetName = getDynamicFieldSetNameOfField(sections, field);
+        if (!fieldSetName ||
+            (fieldSetName &&
+                !mixinsToMutate.mixinsToDelete.includes(fieldSetName) &&
+                (hasNodeMixin(nodeData, fieldSetName) || mixinsToMutate.mixinsToAdd.includes(fieldSetName)))) {
+            propsToDelete.push({
+                name: field.propertyName,
+                language: lang
+            });
         }
     }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

This is a back port of https://github.com/Jahia/jcontent/pull/1753

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
