### PR TITLE
fix: Addressed incorrect artifact name in the sonar workflow

### DIFF
--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -36,8 +36,9 @@ jobs:
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: ${{ matrix.supported_branches }}
-          build_artifacts: build-artifacts-${{ matrix.supported_branches }}
+          build_artifacts: build-artifacts
           github_pr_id: ${{github.event.number}}
           sonar_url: ${{ secrets.SONAR_URL }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
+          nvd_apikey: ${{ secrets.NVD_APIKEY }}
           mvn_settings_filepath: '.github/maven.settings.xml'


### PR DESCRIPTION
### Description

Use default build artifact name internally set by build action

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
