### PR TITLE
chore: Update weekly test config to use snapshot provisioning

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -19,7 +19,6 @@ jobs:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
     with:
       module_id: content-editor
-      module_branch: ${{ github.ref }}
       jahia_image: ${{ matrix.jahia_image }}
       incident_service: content-editor-${{ matrix.config_file }}
       tests_profile: ${{ matrix.config_file }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -19,12 +19,13 @@ jobs:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
     with:
       module_id: content-editor
+      module_branch: ${{ github.ref }}
       jahia_image: ${{ matrix.jahia_image }}
       incident_service: content-editor-${{ matrix.config_file }}
       tests_profile: ${{ matrix.config_file }}
       provisioning_manifest: provisioning-manifest-build.yml
       artifact_prefix: ce-nightly-${{ matrix.config_file }}
       testrail_project: Content Editor
-      jahia_cluster_enabled: true
+      jahia_cluster_enabled: false
       timeout_job: 65
       timeout_step: 50


### PR DESCRIPTION
Give a try with cluster disabled: https://github.com/Jahia/content-editor/actions/runs/25924635854

We have this error:
```
  cypress             | 15 May 2026 - 11:05 == Content of the artifacts/ folder
  cypress             | total 12K
  cypress             | drwxr-xr-x 2 jahians jahians 4.0K May 15 10:57 .
  cypress             | drwx------ 1 jahians jahians 4.0K May 15 10:59 ..
  cypress             | Build directory is empty; artifacts missing - try rerunning the full PR workflow in case of expired artifacts
```

are we supposed to have a [specific env.run.sh script](https://github.com/Jahia/content-editor/blob/fix-ce-tests/tests/env.run.sh)?